### PR TITLE
Add migration for concurrent-download-chunk-size in container-runtime 

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.46.0"
+version = "1.47.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -436,4 +436,6 @@ version = "1.46.0"
 "(1.44.0, 1.45.0)" = []
 "(1.45.0, 1.46.0)" = [
     "migrate_v1.46.0_kubernetes-static-pods-enabled-setting.lz4",
+]
+"(1.46.0, 1.47.0)" = [
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -438,4 +438,5 @@ version = "1.47.0"
     "migrate_v1.46.0_kubernetes-static-pods-enabled-setting.lz4",
 ]
 "(1.46.0, 1.47.0)" = [
+    "migrate_v1.47.0_container-runtime-concurrent-download-chunk-size.lz4",
 ]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "1.46.0"
+release-version = "1.47.0"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -615,6 +615,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "container-runtime-concurrent-download-chunk-size"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "container-runtime-plugins-settings"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -253,9 +253,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bitvec"
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-defaults-helper"
 version = "0.1.1"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "snafu",
  "toml",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "darling",
  "quote",
@@ -323,8 +323,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.10.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+version = "0.11.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -332,6 +332,7 @@ dependencies = [
  "bottlerocket-scalar-derive",
  "bottlerocket-string-impls-for",
  "bounded-integer",
+ "byte-unit",
  "indexmap",
  "lazy_static",
  "regex",
@@ -359,7 +360,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "serde",
  "serde_plain",
@@ -368,7 +369,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -382,7 +383,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -392,8 +393,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.13.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+version = "0.14.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -432,7 +433,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-plugin"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "abi_stable",
  "bottlerocket-settings-derive",
@@ -444,7 +445,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -457,7 +458,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "serde",
 ]
@@ -465,7 +466,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1864,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1877,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1890,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1903,8 +1904,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-bootstrap-containers"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+version = "0.2.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1917,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1930,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1942,8 +1943,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-container-runtime"
-version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+version = "0.3.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1955,13 +1956,12 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-container-runtime-plugins"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+version = "0.2.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "byte-unit",
  "env_logger",
  "lazy_static",
  "regex",
@@ -1973,7 +1973,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1986,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1998,8 +1998,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-host-containers"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+version = "0.2.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2012,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.5.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2104,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2117,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2157,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "settings-migrations/v1.44.0/container-runtime-plugins-settings",
     "settings-migrations/v1.44.0/container-runtime-snapshotter-setting",
     "settings-migrations/v1.46.0/kubernetes-static-pods-enabled-setting",
+    "settings-migrations/v1.47.0/container-runtime-concurrent-download-chunk-size",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -107,27 +107,27 @@ walkdir = "2"
 
 [workspace.dependencies.bottlerocket-defaults-helper]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.13.0"
+tag = "bottlerocket-settings-models-v0.14.0"
 version = "0.1.1"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.13.0"
-version = "0.10.0"
+tag = "bottlerocket-settings-models-v0.14.0"
+version = "0.11.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.13.0"
-version = "0.13.0"
+tag = "bottlerocket-settings-models-v0.14.0"
+version = "0.14.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.13.0"
+tag = "bottlerocket-settings-models-v0.14.0"
 version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.13.0"
+tag = "bottlerocket-settings-models-v0.14.0"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/settings-migrations/v1.47.0/container-runtime-concurrent-download-chunk-size/Cargo.toml
+++ b/sources/settings-migrations/v1.47.0/container-runtime-concurrent-download-chunk-size/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "container-runtime-concurrent-download-chunk-size"
+version = "0.1.0"
+authors = ["Kyle Sessions <kssessio@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.47.0/container-runtime-concurrent-download-chunk-size/src/main.rs
+++ b/sources/settings-migrations/v1.47.0/container-runtime-concurrent-download-chunk-size/src/main.rs
@@ -1,0 +1,21 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new container-runtime setting for:
+/// - concurrent_download_chunk_size
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.container-runtime.concurrent-download-chunk-size",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

* Add migration for:  `concurrent-download-chunk-size` which only works in `containerd-2.1` 
  * https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/645
  * https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/99

**Testing done:**
Re-ran migration with released core-kit.

Tested migration: `1.46.0 -> 1.47.0 -> 1.46.0` on a custom eks-1.33 with containerd-2.1, and on aws-eks-1.32 (where the setting is a no-op) 

1.46.0: 

```
[ssm-user@control]$ apiclient set settings.container-runtime.concurrent-download-chunk-size="32mib"
Failed to change settings: Failed PATCH request to '/settings/keypair?tx=apiclient-set-sSym2oNqz9megGUk': Status 400 when PATCHing /settings/keypair?tx=apiclient-set-sSym2oNqz9megGUk: Unable to match your input to the data model.  We may not have enough type information.  Please try the —json input form.  Cause: Error during deserialization: unknown field concurrent-download-chunk-size, expected one of max-container-log-line-size, max-concurrent-downloads, enable-unprivileged-ports, enable-unprivileged-icmp, snapshotter at line 1 column 54
```

 moved to 1.47.0: 
```
[root@admin]#  apiclient set settings.container-runtime.concurrent-download-chunk-size="32mib"
[root@admin]# apiclient get settings.container-runtime.concurrent-download-chunk-size
{
  "settings": {
    "container-runtime": {
      "concurrent-download-chunk-size": 33554432
    }
  }
}
```

Back to 1.46.0:

```
[ssm-user@control]$ apiclient get settings.container-runtime.concurrent-download-chunk-size
{}
[ssm-user@control]$ apiclient get settings.container-runtime
{}
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
