### PR TITLE
Update 1.47.0 with Core-Kit 10.4.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,14 @@
 
 ## OS Changes
 * Update `bottlerocket-kernel-kit` from 4.2.0 to 4.3.0 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/blob/develop/CHANGELOG.md#v430-2025-09-08) ([commits](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/compare/v4.2.0...v4.3.0)) ([#4637])
-* Update `bottlerocket-core-kit` from 10.3.0 to 10.4.0 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/develop/CHANGELOG.md#v1040-2025-09-08) ([commits](https://github.com/bottlerocket-os/bottlerocket-core-kit/compare/v10.3.0...v10.4.0)) ([#4639])
+* Update `bottlerocket-core-kit` from 10.3.0 to 10.4.1 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/develop/CHANGELOG.md#v1041-2025-09-11) ([commits](https://github.com/bottlerocket-os/bottlerocket-core-kit/compare/v10.3.0...v10.4.1)) ([#4639], [#4642])
 
 [#4631]: https://github.com/bottlerocket-os/bottlerocket/pull/4631
 [#4636]: https://github.com/bottlerocket-os/bottlerocket/pull/4636
 [#4637]: https://github.com/bottlerocket-os/bottlerocket/pull/4637
 [#4638]: https://github.com/bottlerocket-os/bottlerocket/pull/4638
 [#4639]: https://github.com/bottlerocket-os/bottlerocket/pull/4639
+[#4642]: https://github.com/bottlerocket-os/bottlerocket/pull/4642
 [bottlerocket-core-kit#549]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/549
 [bottlerocket-core-kit#581]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/581
 [bottlerocket-core-kit#594]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/594

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -17,7 +17,7 @@ digest = "Cm809ru8wOfjrFukpSQiUSwUtQw0+LVkAZqp0Cs8NqM="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "10.4.0"
+version = "10.4.1"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v10.4.0"
-digest = "Bs/uDNJyv6nHAOBiLzi8ECvvAKEfQgUOU3NTpeUO38Y="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v10.4.1"
+digest = "wzVPmvBY4jYQnUNX8eveeTCwWybVndXmSlwtzDwui6w="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -17,5 +17,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "10.4.0"
+version = "10.4.1"
 vendor = "bottlerocket"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-defaults-helper"
 version = "0.1.1"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "snafu",
  "toml",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "darling",
  "quote",
@@ -324,7 +324,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-modeled-types"
 version = "0.11.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "serde",
  "serde_plain",
@@ -369,7 +369,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -393,8 +393,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.14.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+version = "0.15.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -433,7 +433,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-plugin"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "abi_stable",
  "bottlerocket-settings-derive",
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -458,7 +458,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "serde",
 ]
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1903,7 +1903,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1916,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1943,7 +1943,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1956,7 +1956,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1969,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1981,8 +1981,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-container-runtime"
-version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+version = "0.4.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1995,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2024,7 +2024,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2050,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2063,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.5.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2090,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -2116,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2129,7 +2129,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2155,7 +2155,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2169,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2182,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2195,7 +2195,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -112,27 +112,27 @@ walkdir = "2"
 
 [workspace.dependencies.bottlerocket-defaults-helper]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.14.0"
+tag = "bottlerocket-settings-models-v0.15.0"
 version = "0.1.1"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.14.0"
+tag = "bottlerocket-settings-models-v0.15.0"
 version = "0.11.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.14.0"
-version = "0.14.0"
+tag = "bottlerocket-settings-models-v0.15.0"
+version = "0.15.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.14.0"
+tag = "bottlerocket-settings-models-v0.15.0"
 version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.14.0"
+tag = "bottlerocket-settings-models-v0.15.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
* Bumps to core-kit 10.4.1 and updates Changelog

**Testing done:** 

#### Ran migration test. 
<details>

##### 1.46.0 -> 147.0:
```
[ssm-user@control]$ apiclient apply <<EOF
> [settings.container-runtime]
> snapshotter = "soci"
> [settings.container-runtime-plugins.soci-snapshotter]
> pull-mode = "parallel-pull-unpack"
> [settings.container-runtime-plugins.soci-snapshotter.parallel-pull-unpack]
> concurrent-download-chunk-size = "16mb"
> discard-unpacked-layers = true
> max-concurrent-downloads = 12
> max-concurrent-downloads-per-image = 5
> max-concurrent-unpacks = 8
> max-concurrent-unpacks-per-image = 4
> EOF
[ssm-user@control]$ 

[ssm-user@control]$ apiclient apply <<EOF
> [settings.container-runtime]
> snapshotter = "soci"
> concurrent-download-chunk-size = "8mb"
> [settings.container-runtime-plugins.soci-snapshotter]
> pull-mode = "parallel-pull-unpack"
> [settings.container-runtime-plugins.soci-snapshotter.parallel-pull-unpack]
> concurrent-download-chunk-size = "16mb"
> discard-unpacked-layers = true
> max-concurrent-downloads = 12
> max-concurrent-downloads-per-image = 5
> max-concurrent-unpacks = 8
> max-concurrent-unpacks-per-image = 4
> EOF
[ssm-user@control]$ 

[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "566d00df",
    "pretty_name": "Bottlerocket OS 1.47.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.47.0"
  }
}
[ssm-user@control]$ apiclient get settings.container-runtime
{
  "settings": {
    "container-runtime": {
      "concurrent-download-chunk-size": 8000000,
      "snapshotter": "soci"
    },
    "container-runtime-plugins": {
      "soci-snapshotter": {
        "parallel-pull-unpack": {
          "concurrent-download-chunk-size": 16000000,
          "discard-unpacked-layers": true,
          "max-concurrent-downloads": 12,
          "max-concurrent-downloads-per-image": 5,
          "max-concurrent-unpacks": 8,
          "max-concurrent-unpacks-per-image": 4
        },
        "pull-mode": "parallel-pull-unpack"
      }
    }
  }
}

```

##### 1.47.0 -> 146.0:

```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "624193db",
    "pretty_name": "Bottlerocket OS 1.46.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.46.0"
  }
}
[ssm-user@control]$
[ssm-user@control]$ apiclient get settings.container-runtime
{
  "settings": {
    "container-runtime": {
      "snapshotter": "soci"
    },
    "container-runtime-plugins": {
      "soci-snapshotter": {
        "parallel-pull-unpack": {
          "concurrent-download-chunk-size": 16000000,
          "discard-unpacked-layers": true,
          "max-concurrent-downloads": 12,
          "max-concurrent-downloads-per-image": 5,
          "max-concurrent-unpacks": 8,
          "max-concurrent-unpacks-per-image": 4
        },
        "pull-mode": "parallel-pull-unpack"
      }
    }
  }
}
```

</details>

#### Ran apiclient verification tests:
<details>

```
[ssm-user@control]$ apiclient apply <<EOF
> [settings.container-runtime]
> snapshotter = "soci"
> [settings.container-runtime-plugins.soci-snapshotter]
> pull-mode = "parallel-pull-unpack"
> [settings.container-runtime-plugins.soci-snapshotter.parallel-pull-unpack]
> concurrent-download-chunk-size = "16mb"
> EOF

[ssm-user@control]$ apiclient apply <<EOF
> [settings.container-runtime]
> snapshotter = "overlayfs"
> EOF
[ssm-user@control]$

[ssm-user@control]$ apiclient set settings.container-runtime.concurrent-download-chunk-size="32mib"
[ssm-user@control]$ apiclient get settings.container-runtime.concurrent-download-chunk-size
{
  "settings": {
    "container-runtime": {
      "concurrent-download-chunk-size": 33554432
    }
  }
}
[ssm-user@control]$ apiclient get settings.container-runtime
{
  "settings": {
    "container-runtime": {
      "concurrent-download-chunk-size": 33554432,
      "snapshotter": "overlayfs"
    },
    "container-runtime-plugins": {
      "soci-snapshotter": {
        "parallel-pull-unpack": {
          "concurrent-download-chunk-size": 16000000,
          "discard-unpacked-layers": true,
          "max-concurrent-downloads": 12,
          "max-concurrent-downloads-per-image": 5,
          "max-concurrent-unpacks": 8,
          "max-concurrent-unpacks-per-image": 4
        },
        "pull-mode": "parallel-pull-unpack"
      }
    }
  }
}

```

</details>
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
