### PR TITLE
Add reserved pid settings migration

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.48.0"
+version = "1.49.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -442,3 +442,4 @@ version = "1.48.0"
     "migrate_v1.47.0_host-bootstrap-containers-command-setting.lz4"
 ]
 "(1.47.0, 1.48.0)" = []
+"(1.48.0, 1.49.0)" = []

--- a/Release.toml
+++ b/Release.toml
@@ -442,4 +442,6 @@ version = "1.49.0"
     "migrate_v1.47.0_host-bootstrap-containers-command-setting.lz4"
 ]
 "(1.47.0, 1.48.0)" = []
-"(1.48.0, 1.49.0)" = []
+"(1.48.0, 1.49.0)" = [
+    "migrate_v1.49.0_kubernetes-reserved-pid-settings.lz4"
+]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "1.48.0"
+release-version = "1.49.0"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-defaults-helper"
 version = "0.1.1"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "snafu",
  "toml",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "darling",
  "quote",
@@ -323,8 +323,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.11.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+version = "0.12.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "serde",
  "serde_plain",
@@ -369,7 +369,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -393,8 +393,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.15.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+version = "0.16.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -433,7 +433,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-plugin"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "abi_stable",
  "bottlerocket-settings-derive",
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -458,7 +458,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "serde",
 ]
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1903,7 +1903,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1916,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1943,7 +1943,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1956,7 +1956,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1969,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1982,7 +1982,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1995,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2024,7 +2024,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2050,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2063,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.5.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2090,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -2116,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2129,7 +2129,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2155,7 +2155,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2169,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2182,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2195,7 +2195,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1159,6 +1159,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubernetes-reserved-pid-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubernetes-static-pods-enabled-setting"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -112,27 +112,27 @@ walkdir = "2"
 
 [workspace.dependencies.bottlerocket-defaults-helper]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.15.0"
+tag = "bottlerocket-settings-models-v0.16.0"
 version = "0.1.1"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.15.0"
-version = "0.11.0"
+tag = "bottlerocket-settings-models-v0.16.0"
+version = "0.12.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.15.0"
-version = "0.15.0"
+tag = "bottlerocket-settings-models-v0.16.0"
+version = "0.16.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.15.0"
+tag = "bottlerocket-settings-models-v0.16.0"
 version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.15.0"
+tag = "bottlerocket-settings-models-v0.16.0"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "settings-migrations/v1.46.0/kubernetes-static-pods-enabled-setting",
     "settings-migrations/v1.47.0/container-runtime-concurrent-download-chunk-size",
     "settings-migrations/v1.47.0/host-bootstrap-containers-command-setting",
+    "settings-migrations/v1.49.0/kubernetes-reserved-pid-settings",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/settings-migrations/v1.49.0/kubernetes-reserved-pid-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.49.0/kubernetes-reserved-pid-settings/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kubernetes-reserved-pid-settings"
+version = "0.1.0"
+authors = ["Kush Upadhyay <kushupad@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.49.0/kubernetes-reserved-pid-settings/src/main.rs
+++ b/sources/settings-migrations/v1.49.0/kubernetes-reserved-pid-settings/src/main.rs
@@ -1,0 +1,21 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+// We added new kubernetes settings to reserve pids for kubernetes and system components.
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.kube-reserved.pid",
+        "settings.kubernetes.system-reserved.pid",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to: https://github.com/bottlerocket-os/bottlerocket/issues/3788

**Description of changes:**

Add migration for `pid` setting under `kube-reserved` and `system-reserved` settings:
* https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/98
* https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/646

**Testing done:**

Migration testing:

- Pre-upgrade (expected failure)
```
apiclient set -j '{
 "settings": {
    "kubernetes": {
      "kube-reserved": {
        "pid": "9999",
        "cpu": "10m",
        "ephemeral-storage": "1Gi", 
        "memory": "100Mi"
      },
      "system-reserved": {
        "pid": "1000",
        "cpu": "10m",
        "ephemeral-storage": "1Gi", 
        "memory": "100Mi"
      }
    }
  }
}'

=> Failed to change settings: Failed PATCH request to '/settings?tx=apiclient-set-tK69YYxBmTQgmkyl': Status 400 when PATCHing /settings?tx=apiclient-set-tK69YYxBmTQgmkyl: Json deserialize error: Unable to deserialize into KubernetesReservedResourceKey: Invalid input for field Reserved sources key: unknown variant `pid`, expected one of `cpu`, `memory`, `ephemeral-storage` at line 1 column 37
```

- Upgrade
```
[ssm-user@control]$ apiclient get settings.kubernetes.kube-reserved
{
  "settings": {
    "kubernetes": {
      "kube-reserved": {
        "cpu": "10m",
        "ephemeral-storage": "1Gi",
        "memory": "100Mi",
        "pid": "9999"
      }
    }
  }
}
[ssm-user@control]$ apiclient get settings.kubernetes.system-reserved
{
  "settings": {
    "kubernetes": {
      "system-reserved": {
        "cpu": "10m",
        "ephemeral-storage": "1Gi",
        "memory": "100Mi",
        "pid": "1000"
      }
    }
  }
}
 
=> See the following configs in /etc/kubernetes/kubelet/config where pid is added
kubeReserved:
  cpu: "10m"
  memory: "100Mi"
  ephemeral-storage: "1Gi"
  pid: "9999"
systemReserved:
  cpu: "10m"
  ephemeral-storage: "1Gi"
  memory: "100Mi"
  pid: "1000"
```

- Downgrade
```
[ssm-user@control]$ apiclient get settings.kubernetes.system-reserved
{
  "settings": {
    "kubernetes": {
      "system-reserved": {
        "cpu": "10m",
        "ephemeral-storage": "1Gi",
        "memory": "100Mi"
      }
    }
  }
}
[ssm-user@control]$ apiclient get settings.kubernetes.kube-reserved
{
  "settings": {
    "kubernetes": {
      "kube-reserved": {
        "cpu": "10m",
        "ephemeral-storage": "1Gi",
        "memory": "100Mi"
      }
    }
  }
}

=> See the following configs in /etc/kubernetes/kubelet/config where pid is removed
kubeReserved:
  cpu: "10m"
  memory: "100Mi"
  ephemeral-storage: "1Gi"
systemReserved:
  cpu: "10m"
  ephemeral-storage: "1Gi"
  memory: "100Mi"
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
