### PR TITLE
Bump EOL containerd-2.0 to containerd-2.1 on aws-k8-1.33-* + vmware-k8s-1.33-* variants

### DIFF
--- a/variants/aws-k8s-1.33-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-fips/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.1",
-    "containerd-2.0",
+    "containerd-2.1",
 # k8s
     "cni",
     "cni-plugins",

--- a/variants/aws-k8s-1.33-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.0",
+    "containerd-2.1",
     # k8s
     "cni",
     "cni-plugins",

--- a/variants/aws-k8s-1.33/Cargo.toml
+++ b/variants/aws-k8s-1.33/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.0",
+    "containerd-2.1",
 # k8s
     "cni",
     "cni-plugins",

--- a/variants/vmware-k8s-1.33-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.33-fips/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.0",
+    "containerd-2.1",
     # k8s
     "cni",
     "cni-plugins",

--- a/variants/vmware-k8s-1.33/Cargo.toml
+++ b/variants/vmware-k8s-1.33/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.0",
+    "containerd-2.1",
     # k8s
     "cni",
     "cni-plugins",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->
**Issue:**

Closes https://github.com/bottlerocket-os/bottlerocket/issues/4686

**Description of changes:**

* Bump EOL containerd-2.0 to containerd-2.1 on aws-k8-1.33-* + vmware-k8s-1.33-* variants

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
