### PR TITLE
Update ecr-credential-provider image patterns

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.50.0"
+version = "1.51.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -444,4 +444,7 @@ version = "1.50.0"
 "(1.48.0, 1.49.0)" = []
 "(1.49.0, 1.50.0)" = [
     "migrate_v1.50.0_kubernetes-reserved-pid-settings.lz4",
+]
+"(1.50.0, 1.51.0)" = [
+    "migrate_v1.51.0_kubernetes-ecr-credential-provider-patterns.lz4",
 ]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "1.50.0"
+release-version = "1.51.0"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1138,6 +1138,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubernetes-ecr-credential-provider-patterns"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubernetes-ecr-credential-providers-correction"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "settings-migrations/v1.47.0/container-runtime-concurrent-download-chunk-size",
     "settings-migrations/v1.47.0/host-bootstrap-containers-command-setting",
     "settings-migrations/v1.50.0/kubernetes-reserved-pid-settings",
+    "settings-migrations/v1.51.0/kubernetes-ecr-credential-provider-patterns",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/settings-migrations/v1.51.0/kubernetes-ecr-credential-provider-patterns/Cargo.toml
+++ b/sources/settings-migrations/v1.51.0/kubernetes-ecr-credential-provider-patterns/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kubernetes-ecr-credential-provider-patterns"
+version = "0.1.0"
+authors = ["Sam Berning <bernings@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.51.0/kubernetes-ecr-credential-provider-patterns/src/main.rs
+++ b/sources/settings-migrations/v1.51.0/kubernetes-ecr-credential-provider-patterns/src/main.rs
@@ -1,0 +1,54 @@
+use migration_helpers::common_migrations::{ListReplacement, ReplaceListsMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new hostname patterns to be matched by the ECR credential provider.
+fn run() -> Result<()> {
+    migrate(ReplaceListsMigration(vec![ListReplacement {
+        setting: "settings.kubernetes.credential-providers.ecr-credential-provider.image-patterns",
+        old_vals: &[
+            "*.dkr.ecr.*.amazonaws.com",
+            "*.dkr.ecr.*.amazonaws.com.cn",
+            "*.dkr.ecr.*.on.aws",
+            "*.dkr.ecr.*.on.amazonwebservices.com.cn",
+            "*.dkr.ecr-fips.*.amazonaws.com",
+            "*.dkr.ecr.*.cloud.adc-e.uk",
+            "*.dkr.ecr-fips.*.cloud.adc-e.uk",
+            "*.dkr.ecr.*.c2s.ic.gov",
+            "*.dkr.ecr-fips.*.c2s.ic.gov",
+            "*.dkr.ecr.*.sc2s.sgov.gov",
+            "*.dkr.ecr-fips.*.sc2s.sgov.gov",
+            "*.dkr.ecr.*.csp.hci.ic.gov",
+            "*.dkr.ecr-fips.*.csp.hci.ic.gov",
+            "public.ecr.aws",
+        ],
+        new_vals: &[
+            "*.dkr.ecr.*.amazonaws.com",
+            "*.dkr.ecr.*.amazonaws.com.cn",
+            "*.dkr.ecr.*.amazonaws.eu",
+            "*.dkr.ecr.*.on.aws",
+            "*.dkr.ecr.*.on.amazonwebservices.com.cn",
+            "*.dkr.ecr-fips.*.amazonaws.com",
+            "*.dkr.ecr-fips.*.amazonaws.eu",
+            "*.dkr.ecr.*.cloud.adc-e.uk",
+            "*.dkr.ecr-fips.*.cloud.adc-e.uk",
+            "*.dkr.ecr.*.c2s.ic.gov",
+            "*.dkr.ecr-fips.*.c2s.ic.gov",
+            "*.dkr.ecr.*.sc2s.sgov.gov",
+            "*.dkr.ecr-fips.*.sc2s.sgov.gov",
+            "*.dkr.ecr.*.csp.hci.ic.gov",
+            "*.dkr.ecr-fips.*.csp.hci.ic.gov",
+            "public.ecr.aws",
+        ],
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/kubernetes-aws-credential-provider.toml
+++ b/sources/shared-defaults/kubernetes-aws-credential-provider.toml
@@ -4,9 +4,11 @@ cache-duration = "12h"
 image-patterns = [
     "*.dkr.ecr.*.amazonaws.com",
     "*.dkr.ecr.*.amazonaws.com.cn",
+    "*.dkr.ecr.*.amazonaws.eu",
     "*.dkr-ecr.*.on.aws",
     "*.dkr-ecr.*.on.amazonwebservices.com.cn",
     "*.dkr.ecr-fips.*.amazonaws.com",
+    "*.dkr.ecr-fips.*.amazonaws.eu",
     "*.dkr.ecr.*.cloud.adc-e.uk",
     "*.dkr.ecr-fips.*.cloud.adc-e.uk",
     "*.dkr.ecr.*.c2s.ic.gov",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

- Update the image patterns to include EUSC image formats
- Add a migration from the old image patterns to the new ones

**Testing done:**

- Built an AMI with these changes and tested that it calls ecr-credential-provider with EUSC image patterns


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
