### PR TITLE
k8s settings migrations for v1.51.0

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -449,4 +449,5 @@ version = "1.51.0"
 "(1.50.0, 1.51.0)" = [
     "migrate_v1.51.0_kubernetes-ecr-credential-provider-patterns.lz4",
     "migrate_v1.51.0_kubernetes-additional-settings.lz4",
+    "migrate_v1.51.0_kubernetes-beta-cpu-manager-policy-options.lz4",
 ]

--- a/Release.toml
+++ b/Release.toml
@@ -448,4 +448,5 @@ version = "1.51.0"
 ]
 "(1.50.0, 1.51.0)" = [
     "migrate_v1.51.0_kubernetes-ecr-credential-provider-patterns.lz4",
+    "migrate_v1.51.0_kubernetes-additional-settings.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-defaults-helper"
 version = "0.1.1"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "snafu",
  "toml",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "darling",
  "quote",
@@ -323,8 +323,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.12.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+version = "0.13.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "serde",
  "serde_plain",
@@ -369,7 +369,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -393,8 +393,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.16.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+version = "0.17.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -415,6 +415,7 @@ dependencies = [
  "settings-extension-dns",
  "settings-extension-ecs",
  "settings-extension-host-containers",
+ "settings-extension-image-verifier-plugins",
  "settings-extension-kernel",
  "settings-extension-kubelet-device-plugins",
  "settings-extension-kubernetes",
@@ -433,7 +434,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-plugin"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "abi_stable",
  "bottlerocket-settings-derive",
@@ -445,7 +446,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -458,7 +459,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "serde",
 ]
@@ -466,7 +467,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1917,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1930,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1943,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1957,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1970,7 +1971,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1983,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1996,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2009,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2025,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2038,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2051,7 +2052,20 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+dependencies = [
+ "bottlerocket-model-derive",
+ "bottlerocket-modeled-types",
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "settings-extension-image-verifier-plugins"
+version = "0.1.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2064,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2077,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2089,8 +2103,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubernetes"
-version = "0.5.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+version = "0.6.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2104,7 +2118,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2117,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -2130,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2143,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2156,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2169,7 +2183,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2183,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2196,7 +2210,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2209,7 +2223,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1139,6 +1139,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubernetes-additional-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubernetes-ecr-credential-provider-patterns"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1146,6 +1146,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubernetes-beta-cpu-manager-policy-options"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubernetes-ecr-credential-provider-patterns"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "settings-migrations/v1.47.0/host-bootstrap-containers-command-setting",
     "settings-migrations/v1.50.0/kubernetes-reserved-pid-settings",
     "settings-migrations/v1.51.0/kubernetes-ecr-credential-provider-patterns",
+    "settings-migrations/v1.51.0/kubernetes-additional-settings",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "settings-migrations/v1.50.0/kubernetes-reserved-pid-settings",
     "settings-migrations/v1.51.0/kubernetes-ecr-credential-provider-patterns",
     "settings-migrations/v1.51.0/kubernetes-additional-settings",
+    "settings-migrations/v1.51.0/kubernetes-beta-cpu-manager-policy-options",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -114,27 +114,27 @@ walkdir = "2"
 
 [workspace.dependencies.bottlerocket-defaults-helper]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.16.0"
+tag = "bottlerocket-settings-models-v0.17.0"
 version = "0.1.1"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.16.0"
-version = "0.12.0"
+tag = "bottlerocket-settings-models-v0.17.0"
+version = "0.13.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.16.0"
-version = "0.16.0"
+tag = "bottlerocket-settings-models-v0.17.0"
+version = "0.17.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.16.0"
+tag = "bottlerocket-settings-models-v0.17.0"
 version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.16.0"
+tag = "bottlerocket-settings-models-v0.17.0"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/api/migration/migration-helpers/src/common_migrations.rs
+++ b/sources/api/migration/migration-helpers/src/common_migrations.rs
@@ -738,6 +738,203 @@ impl Migration for NoOpMigration {
 
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
+/// We use this migration when we add new values to a list setting that older versions don't
+/// understand. On downgrade, we filter the list to only include values the old version accepts.
+pub struct ListRestriction {
+    pub setting: &'static str,
+    pub allowed_vals: &'static [&'static str],
+}
+
+pub struct RestrictListsMigration(pub Vec<ListRestriction>);
+
+impl Migration for RestrictListsMigration {
+    /// New versions can handle all values; no work needed on upgrade.
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        println!(
+            "RestrictListsMigration({:?}) has no work to do on upgrade.",
+            self.0.iter().map(|r| r.setting).collect::<Vec<_>>()
+        );
+        Ok(input)
+    }
+
+    /// Older versions only understand certain values; remove any values not in the allowed list.
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        for restriction in &self.0 {
+            if let Some(data) = input.data.get_mut(restriction.setting) {
+                match data {
+                    serde_json::Value::Array(data) => {
+                        let list: Vec<&str> = data
+                            .iter()
+                            .map(|v| v.as_str())
+                            .collect::<Option<Vec<&str>>>()
+                            .with_context(|| error::ReplaceListContentsSnafu {
+                                setting: restriction.setting,
+                                data: data.clone(),
+                            })?;
+
+                        let filtered: Vec<&str> = list
+                            .into_iter()
+                            .filter(|val| restriction.allowed_vals.contains(val))
+                            .collect();
+
+                        if filtered.len() != data.len() {
+                            let new_data: Vec<serde_json::Value> =
+                                filtered.iter().map(|s| (*s).into()).collect();
+                            println!(
+                                "Filtered '{}' to allowed values {:?} on downgrade",
+                                restriction.setting, filtered
+                            );
+                            *data = new_data;
+                        } else {
+                            println!(
+                                "'{}' already contains only allowed values, leaving alone",
+                                restriction.setting
+                            );
+                        }
+                    }
+                    _ => {
+                        println!(
+                            "'{}' is set to non-list value '{}'; RestrictListsMigration only handles lists",
+                            restriction.setting, data
+                        );
+                    }
+                }
+            } else {
+                println!("Found no '{}' to filter on downgrade", restriction.setting);
+            }
+        }
+        Ok(input)
+    }
+}
+
+#[cfg(test)]
+mod test_restrict_lists {
+    use super::{ListRestriction, RestrictListsMigration};
+    use crate::{Migration, MigrationData};
+    use maplit::hashmap;
+    use std::collections::HashMap;
+
+    #[test]
+    fn filter_values() {
+        let data = MigrationData {
+            data: hashmap! {
+                "setting".into() => vec!["old1", "old2", "new1", "new2"].into(),
+            },
+            metadata: HashMap::new(),
+        };
+        let result = RestrictListsMigration(vec![ListRestriction {
+            setting: "setting",
+            allowed_vals: &["old1", "old2"],
+        }])
+        .backward(data)
+        .unwrap();
+        assert_eq!(
+            result.data,
+            hashmap! {
+                "setting".into() => vec!["old1", "old2"].into(),
+            }
+        );
+    }
+
+    #[test]
+    fn no_filtering_needed() {
+        let data = MigrationData {
+            data: hashmap! {
+                "setting".into() => vec!["old1", "old2"].into(),
+            },
+            metadata: HashMap::new(),
+        };
+        let result = RestrictListsMigration(vec![ListRestriction {
+            setting: "setting",
+            allowed_vals: &["old1", "old2", "new1"],
+        }])
+        .backward(data)
+        .unwrap();
+        assert_eq!(
+            result.data,
+            hashmap! {
+                "setting".into() => vec!["old1", "old2"].into(),
+            }
+        );
+    }
+
+    #[test]
+    fn forward_no_change() {
+        let data = MigrationData {
+            data: hashmap! {
+                "setting".into() => vec!["old1", "new1", "new2"].into(),
+            },
+            metadata: HashMap::new(),
+        };
+        let result = RestrictListsMigration(vec![ListRestriction {
+            setting: "setting",
+            allowed_vals: &["old1"],
+        }])
+        .forward(data)
+        .unwrap();
+        assert_eq!(
+            result.data,
+            hashmap! {
+                "setting".into() => vec!["old1", "new1", "new2"].into(),
+            }
+        );
+    }
+
+    #[test]
+    fn multiple_restrictions() {
+        let data = MigrationData {
+            data: hashmap! {
+                "setting1".into() => vec!["a", "b", "c"].into(),
+                "setting2".into() => vec!["x", "y", "z"].into(),
+            },
+            metadata: HashMap::new(),
+        };
+        let result = RestrictListsMigration(vec![
+            ListRestriction {
+                setting: "setting1",
+                allowed_vals: &["a", "b"],
+            },
+            ListRestriction {
+                setting: "setting2",
+                allowed_vals: &["x"],
+            },
+        ])
+        .backward(data)
+        .unwrap();
+        assert_eq!(
+            result.data,
+            hashmap! {
+                "setting1".into() => vec!["a", "b"].into(),
+                "setting2".into() => vec!["x"].into(),
+            }
+        );
+    }
+
+    #[test]
+    fn not_list() {
+        let data = MigrationData {
+            data: hashmap! {
+                "setting".into() => "not a list".into(),
+            },
+            metadata: HashMap::new(),
+        };
+        let result = RestrictListsMigration(vec![ListRestriction {
+            setting: "setting",
+            allowed_vals: &["old1"],
+        }])
+        .backward(data)
+        .unwrap();
+        assert_eq!(
+            result.data,
+            hashmap! {
+                "setting".into() => "not a list".into(),
+            }
+        );
+    }
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
 /// We use this migration to remove a setting string if it matches the old value.
 /// We will need this migration once to adapt the concept of Strength on settings.
 pub struct RemoveMatchingString {

--- a/sources/settings-migrations/v1.51.0/kubernetes-additional-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.51.0/kubernetes-additional-settings/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "kubernetes-additional-settings"
+version = "0.1.0"
+authors = ["Kush Upadhyay <kushupad@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.51.0/kubernetes-additional-settings/src/main.rs
+++ b/sources/settings-migrations/v1.51.0/kubernetes-additional-settings/src/main.rs
@@ -1,0 +1,23 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+// We added new kubernetes settings to configure:
+// - min/max duration before an unused image is garbage-collected
+// - max number of image pulls in parallel
+// - mapping length of UIDs and GIDs
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.image-minimum-gc-age",
+        "settings.kubernetes.image-maximum-gc-age",
+        "settings.kubernetes.max-parallel-image-pulls",
+        "settings.kubernetes.ids-per-pod",
+    ]))
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.51.0/kubernetes-beta-cpu-manager-policy-options/Cargo.toml
+++ b/sources/settings-migrations/v1.51.0/kubernetes-beta-cpu-manager-policy-options/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "kubernetes-beta-cpu-manager-policy-options"
+version = "0.1.0"
+authors = ["Kush Upadhyay <kushupad@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.51.0/kubernetes-beta-cpu-manager-policy-options/src/main.rs
+++ b/sources/settings-migrations/v1.51.0/kubernetes-beta-cpu-manager-policy-options/src/main.rs
@@ -1,0 +1,24 @@
+use migration_helpers::common_migrations::{ListRestriction, RestrictListsMigration};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+// Beta options for cpu-manager-policy-options became available without feature gates:
+// - strict-cpu-reservation: 1.32 or higher
+// - distribute-cpus-across-numa: 1.33 or higher
+// - prefer-align-cpus-by-uncorecache: 1.34 or higher
+//
+// On downgrade, we remove these newer options to prevent kubelet from receiving
+// incompatible configuration values. We keep full-pcpus-only as it's stable.
+fn run() -> Result<()> {
+    migrate(RestrictListsMigration(vec![ListRestriction {
+        setting: "settings.kubernetes.cpu-manager-policy-options",
+        allowed_vals: &["full-pcpus-only"],
+    }]))
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->
**Issue number:**

Closes:
bottlerocket-os/bottlerocket#4058
bottlerocket-os/bottlerocket#4453
bottlerocket-os/bottlerocket#4544
bottlerocket-os/bottlerocket#4643
bottlerocket-os/bottlerocket#4675

**Description of changes:**

Add migration for the following k8s settings:
- `image-minimum-gc-age`
- `image-maximum-gc-age`
- `max-parallel-image-pulls`
- `ids-per-pod`


Add another migration for the Beta options for `cpu-manager-policy-options` (`strict-cpu-reservation`, `distribute-cpus-across-numa`, `prefer-align-cpus-by-uncorecache`). Since the `cpu-manager-policy-options` setting is a list, the behavior we want is that on downgrade, these newly added Beta options are removed from that list and not applied, while the stable option `full-pcpus-only` remains if present. This required a new migration-helper `RestrictListsMigration` courtesy of @bcressey.

Related:
* https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/104
* https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/689

**Testing done:**
Migration testing on aws-k8s-1.34 x86 ami:

Pre-upgrade (expected failure):
```
apiclient set -j '{
  "settings": {
    "kubernetes": {
      "image-minimum-gc-age": "2m",
      "image-maximum-gc-age": "24h",
      "max-parallel-image-pulls": 5,
      "ids-per-pod": 131072
    }
  }
}'
 
Failed to change settings: Failed PATCH request to '/settings?tx=apiclient-set-y5PQvMCGsEiS6hWF': Status 400 when PATCHing /settings?tx=apiclient-set-y5PQvMCGsEiS6hWF: Json deserialize error: unknown field `ids-per-pod`, expected one of ... at line 1 column 28
```

Upgrade:
```
[ssm-user@control]$ apiclient get settings.kubernetes.image-minimum-gc-age
{
  "settings": {
    "kubernetes": {
      "image-minimum-gc-age": "2m"
    }
  }
}
[ssm-user@control]$ apiclient get settings.kubernetes.image-maximum-gc-age
{
  "settings": {
    "kubernetes": {
      "image-maximum-gc-age": "24h"
    }
  }
}
[ssm-user@control]$ apiclient get settings.kubernetes.max-parallel-image-pulls
{
  "settings": {
    "kubernetes": {
      "max-parallel-image-pulls": 5
    }
  }
}
[ssm-user@control]$ apiclient get settings.kubernetes.ids-per-pod
{
  "settings": {
    "kubernetes": {
      "ids-per-pod": 131072
    }
  }
}
 
=> See the following configs in /etc/kubernetes/kubelet/config
imageMinimumGCAge: 2m
imageMaximumGCAge: 24h
idsPerPod: 131072
maxParallelImagePulls: 5
```

Downgrade:
```
[ssm-user@control]$ apiclient get settings.kubernetes.image-minimum-gc-age
{}
[ssm-user@control]$ apiclient get settings.kubernetes.image-maximum-gc-age
{}
[ssm-user@control]$  apiclient get settings.kubernetes.max-parallel-image-pulls
{}
[ssm-user@control]$ apiclient get settings.kubernetes.ids-per-pod
{}

=> Values are removed from etc/kubernetes/kubelet/config
```

**Beta options**
Migration testing on aws-k8s-1.33 x86 ami:

Upgrade:
```
apiclient set -j '{
  "settings": {
    "kubernetes": {
      "cpu-manager-policy": "static",
      "cpu-manager-policy-options": ["full-pcpus-only", "strict-cpu-reservation"]
    }
  }
}'

[ssm-user@control]$ apiclient get settings.kubernetes.cpu-manager-policy-options
{
  "settings": {
    "kubernetes": {
      "cpu-manager-policy-options": [
        "full-pcpus-only",
        "strict-cpu-reservation"
      ]
    }
  }
}

=> See the following configs in /etc/kubernetes/kubelet/config
cpuManagerPolicy: static
cpuManagerPolicyOptions:
    full-pcpus-only: "true"
    strict-cpu-reservation: "true"
```

*Needed to reboot the node as described [here](https://bottlerocket.dev/en/os/1.49.x/api/settings/kubernetes/#cpu-manager-policy) for the kubelet to function correctly. After reboot, node remains connected to cluster.*

Downgrade:
```
[ssm-user@control]$ apiclient get settings.kubernetes.cpu-manager-policy-options
{
  "settings": {
    "kubernetes": {
      "cpu-manager-policy-options": [
        "full-pcpus-only"
      ]
    }
  }
}
 
=> See the following configs in /etc/kubernetes/kubelet/config
cpuManagerPolicy: static
cpuManagerPolicyOptions:
    full-pcpus-only: "true"
```

*kubelet works properly without reboot and node remains connected to cluster*

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
