### PR TITLE
build: update core-kit to v11.0.0

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -17,7 +17,7 @@ digest = "eyCbIyioLHokRb9UraADeRjNV2XUSc0lTXPkU1iBbCE="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "10.9.0"
+version = "11.0.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v10.9.0"
-digest = "+OIyEEdCGL2E8+GZUzcEnnspggdLmjV1R6VH1R3C0Cg="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v11.0.0"
+digest = "DEgNQymPZfQMZ45Zd3iHS/QbWJSlTKbbAhRT7IVyVKQ="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -17,5 +17,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "10.9.0"
+version = "11.0.0"
 vendor = "bottlerocket"

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -37,7 +37,6 @@ included-packages = [
     "strace",
     "chrony-tools",
     "soci-snapshotter",
-    "socat",
 ]
 
 [lib]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

* build: update core-kit to v11.0.0
* corekit 11.0.0 dropped socat, so we need to remove it from `aws-dev`

**Testing done:**
cargo build


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
