### PR TITLE
Use whippet in ECS-2 and aws-k8s-1.34 variants

### DIFF
--- a/variants/aws-ecs-2-fips/Cargo.toml
+++ b/variants/aws-ecs-2-fips/Cargo.toml
@@ -19,6 +19,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.1",
+    "whippet",
 # docker
     "docker-cli",
     "docker-engine",

--- a/variants/aws-ecs-2-nvidia/Cargo.toml
+++ b/variants/aws-ecs-2-nvidia/Cargo.toml
@@ -19,6 +19,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.1",
+    "whippet",
 # docker
     "docker-cli",
     "docker-engine",

--- a/variants/aws-ecs-2/Cargo.toml
+++ b/variants/aws-ecs-2/Cargo.toml
@@ -18,6 +18,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.1",
+    "whippet",
 # docker
     "docker-cli",
     "docker-engine",

--- a/variants/aws-k8s-1.34-fips/Cargo.toml
+++ b/variants/aws-k8s-1.34-fips/Cargo.toml
@@ -26,6 +26,7 @@ included-packages = [
     "containerd-2.1",
     "systemd-257",
     "nftables",
+    "whippet",
 # k8s
     "cni",
     "cni-plugins",

--- a/variants/aws-k8s-1.34-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.34-nvidia/Cargo.toml
@@ -28,6 +28,7 @@ included-packages = [
     "containerd-2.1",
     "systemd-257",
     "nftables",
+    "whippet",
     # k8s
     "cni",
     "cni-plugins",

--- a/variants/aws-k8s-1.34/Cargo.toml
+++ b/variants/aws-k8s-1.34/Cargo.toml
@@ -25,6 +25,7 @@ included-packages = [
     "containerd-2.1",
     "systemd-257",
     "nftables",
+    "whippet",
 # k8s
     "cni",
     "cni-plugins",

--- a/variants/vmware-k8s-1.34-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.34-fips/Cargo.toml
@@ -39,6 +39,7 @@ included-packages = [
     "containerd-2.1",
     "systemd-257",
     "nftables",
+    "whippet",
     # k8s
     "cni",
     "cni-plugins",

--- a/variants/vmware-k8s-1.34/Cargo.toml
+++ b/variants/vmware-k8s-1.34/Cargo.toml
@@ -38,6 +38,7 @@ included-packages = [
     "containerd-2.1",
     "systemd-257",
     "nftables",
+    "whippet",
     # k8s
     "cni",
     "cni-plugins",


### PR DESCRIPTION
**Description of changes:**
Replace the `dbus-launcher` with `whippet` in ECS-2 and aws-k8s-1.34 variants


**Testing done:**
- Build AMIs, for both arches, confirmed that `whippet` is installed and `dbus-launcher` isn't
- Conformance and internal ECS testing passing for variants in both arches

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
