### PR TITLE
workflows: use general check task for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,7 @@ jobs:
       - name: Preflight step to set up the runner
         uses: ./.github/actions/setup-node
       - run: rustup component add rustfmt
-      - run: cargo make unit-tests
-      - run: cargo make check-fmt
-      - run: cargo make check-clippy
-      - run: cargo make check-shell
+      - run: cargo make check
       - run: |
           cargo make \
             -e BUILDSYS_ARCH=${{ matrix.arch }} \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Currently, the `build.yml` workflow only runs a subset of individual checks we have in twoliter. Replacing them with [the general `check` task](https://github.com/bottlerocket-os/twoliter/blob/13daaca74cd0c00f884273ed08cc227dcb4c17a2/twoliter/embedded/Makefile.toml#L449) which runs all checks -- particularly `check-migrations` following this PR: 
* https://github.com/bottlerocket-os/twoliter/pull/598

**Testing done:**

Ran `check` and verified all tasks are run and pass.

```
$ cargo make check
[cargo-make][1] INFO - Running Task: unit-tests
[cargo-make][1] INFO - Running Task: check-fmt
[cargo-make][1] INFO - Running Task: check-clippy
[cargo-make][1] INFO - Running Task: check-shell
[cargo-make][1] INFO - Running Task: check-golangci-lint
[cargo-make][1] INFO - Running Task: check-migrations
[cargo-make][1] INFO - Build Done in 23.85 seconds.
[cargo-make] INFO - Build Done in 27.79 seconds.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
