### PR TITLE
shared-defaults: ecs: update aws config to set use_fips_endpoint to false

### DIFF
--- a/sources/shared-defaults/ecs.toml
+++ b/sources/shared-defaults/ecs.toml
@@ -27,3 +27,9 @@ affected-services = ["containerd", "docker", "ecs", "host-containerd", "host-con
 # Image registry credentials
 [metadata.settings.container-registry.credentials]
 affected-services = ["ecs", "host-containers", "bootstrap-containers"]
+
+# Set use_fips_endpoint=false on all ECS variants as expected by the ECS agent.
+# [default]
+# use_fips_endpoint=false
+[settings.aws]
+config="W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"


### PR DESCRIPTION
Code change dependency: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/760
Issue Related to https://github.com/aws/amazon-ecs-agent/issues/4538


**Description of changes:**
Recent ecs-agent updates introduced an incompatibility when using FIPS ECR endpoints alongside use_fips_endpoint=true, requiring us to choose one approach.

We opted to let users specify FIPS ECR endpoints directly.

**Testing done:**

* see:  https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/760

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
