### PR TITLE
Move older variants to NVIDIA 580

### DIFF
--- a/variants/aws-ecs-2-nvidia-fips/Cargo.toml
+++ b/variants/aws-ecs-2-nvidia-fips/Cargo.toml
@@ -31,7 +31,7 @@ included-packages = [
 # NVIDIA support
     "ecs-gpu-init",
     "nvidia-container-toolkit-ecs",
-    "kmod-6.1-nvidia-r570-tesla",
+    "kmod-6.1-nvidia-r580-tesla",
 ]
 
 kernel-parameters = [

--- a/variants/aws-ecs-2-nvidia/Cargo.toml
+++ b/variants/aws-ecs-2-nvidia/Cargo.toml
@@ -30,7 +30,7 @@ included-packages = [
 # NVIDIA support
     "ecs-gpu-init",
     "nvidia-container-toolkit-ecs",
-    "kmod-6.1-nvidia-r570-tesla",
+    "kmod-6.1-nvidia-r580-tesla",
 ]
 
 kernel-parameters = [

--- a/variants/aws-k8s-1.29-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.29-nvidia-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.1-nvidia-r570-tesla",
+    "kmod-6.1-nvidia-r580-tesla",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.29-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.29-nvidia/Cargo.toml
@@ -33,7 +33,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.1-nvidia-r570-tesla",
+    "kmod-6.1-nvidia-r580-tesla",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.30-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.30-nvidia-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.1-nvidia-r570-tesla",
+    "kmod-6.1-nvidia-r580-tesla",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.30-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.30-nvidia/Cargo.toml
@@ -33,7 +33,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.1-nvidia-r570-tesla",
+    "kmod-6.1-nvidia-r580-tesla",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.31-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.31-nvidia-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.1-nvidia-r570-tesla",
+    "kmod-6.1-nvidia-r580-tesla",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.31-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.31-nvidia/Cargo.toml
@@ -33,7 +33,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.1-nvidia-r570-tesla",
+    "kmod-6.1-nvidia-r580-tesla",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.32-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.32-nvidia-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.1-nvidia-r570-tesla",
+    "kmod-6.1-nvidia-r580-tesla",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.32-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.32-nvidia/Cargo.toml
@@ -33,7 +33,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.1-nvidia-r570-tesla",
+    "kmod-6.1-nvidia-r580-tesla",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.33-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia-fips/Cargo.toml
@@ -37,7 +37,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.12-nvidia-r570-tesla",
+    "kmod-6.12-nvidia-r580-tesla",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.33-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",
-    "kmod-6.12-nvidia-r570-tesla",
+    "kmod-6.12-nvidia-r580-tesla",
 ]
 kernel-parameters = [
     "console=tty0",


### PR DESCRIPTION
**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket-kernel-kit/issues/254

**Description of changes:**
This moves the remaining variants to the 580 branch from 570. NVIDIA has marked the 570 end of life in [February of 2026](https://docs.nvidia.com/datacenter/tesla/drivers/supported-drivers-and-cuda-toolkit-versions.html) so this is in preparation for that change.


**Testing done:**
Built images and verified they are on 580.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
