### PR TITLE
chore: bump Twoliter to 0.16.0

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,9 +8,9 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 # For binary installation, this should be a released version (prefixed with a v,
 # for example v0.1.0). For the git sourcecode installation method, this can be
 # any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.15.1"
-TWOLITER_SHA256_AARCH64 = "17acd1bf4764b31074e10269b2ef993b9dce63d9640cc6fd45eeded31e78aadc"
-TWOLITER_SHA256_X86_64 = "a0720d8b2fba1dbf4595c3bc9cca8c6881faaa1af35b9339ed57aef44677c2eb"
+TWOLITER_VERSION = "v0.16.0"
+TWOLITER_SHA256_AARCH64 = "c0586e977c15841eb7f948b9d47a6f798cfa6987d55ba30086b7f04ae3ca5988"
+TWOLITER_SHA256_X86_64 = "c5f38cd5b93fff04f3cf8f2a614193b243179a790ac98a3e23eb767696e254d4"
 
 # For binary installation, this is the GitHub repository that has binary release artifacts attached
 # to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Update Twoliter to 0.16.0

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
