### PR TITLE
variants: add k8s-1.35 variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-k8s-1_35"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "aws-k8s-1_35-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "aws-k8s-1_35-nvidia"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "aws-k8s-1_35-nvidia-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
 name = "metal-dev"
 version = "0.1.0"
 dependencies = [
@@ -430,6 +466,24 @@ dependencies = [
 
 [[package]]
 name = "vmware-k8s-1_34-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "vmware-k8s-1_35"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "vmware-k8s-1_35-fips"
 version = "0.1.0"
 dependencies = [
  "settings-defaults",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ members = [
     "variants/aws-k8s-1.33-fips",
     "variants/aws-k8s-1.34",
     "variants/aws-k8s-1.34-fips",
+    "variants/aws-k8s-1.35",
+    "variants/aws-k8s-1.35-fips",
     "variants/aws-k8s-1.29-nvidia",
     "variants/aws-k8s-1.29-nvidia-fips",
     "variants/aws-k8s-1.30-nvidia",
@@ -37,6 +39,8 @@ members = [
     "variants/aws-k8s-1.33-nvidia-fips",
     "variants/aws-k8s-1.34-nvidia",
     "variants/aws-k8s-1.34-nvidia-fips",
+    "variants/aws-k8s-1.35-nvidia",
+    "variants/aws-k8s-1.35-nvidia-fips",
     "variants/metal-dev",
     "variants/vmware-dev",
     "variants/vmware-k8s-1.29",
@@ -51,6 +55,8 @@ members = [
     "variants/vmware-k8s-1.33-fips",
     "variants/vmware-k8s-1.34",
     "variants/vmware-k8s-1.34-fips",
+    "variants/vmware-k8s-1.35",
+    "variants/vmware-k8s-1.35-fips",
 ]
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -67,12 +67,14 @@ The following variants support EKS, as described above:
 * `aws-k8s-1.32`
 * `aws-k8s-1.33`
 * `aws-k8s-1.34`
+* `aws-k8s-1.35`
 * `aws-k8s-1.29-nvidia`
 * `aws-k8s-1.30-nvidia`
 * `aws-k8s-1.31-nvidia`
 * `aws-k8s-1.32-nvidia`
 * `aws-k8s-1.33-nvidia`
 * `aws-k8s-1.34-nvidia`
+* `aws-k8s-1.35-nvidia`
 
 The following variants support ECS:
 
@@ -90,6 +92,7 @@ We also have variants that are designed to be Kubernetes worker nodes in VMware:
 * `vmware-k8s-1.32`
 * `vmware-k8s-1.33`
 * `vmware-k8s-1.34`
+* `vmware-k8s-1.35`
 
 The following variants are no longer supported:
 

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -17,7 +17,7 @@ digest = "+iBHhekVVER58JhyEFs3aSGdYb2D55lG6vVgNvXm9A0="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "12.0.1"
+version = "12.2.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v12.0.1"
-digest = "iLjbTfU19pWc5eDoeJKx+itSFRutNjNx6w/1kgk9+bw="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v12.2.0"
+digest = "3r2Iq3DCVaXO019LnP9pgobbO1a7N8tXdHqokupBWRM="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -17,5 +17,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "12.0.1"
+version = "12.2.0"
 vendor = "bottlerocket"

--- a/packages/settings-defaults/settings-defaults.spec
+++ b/packages/settings-defaults/settings-defaults.spec
@@ -211,6 +211,34 @@ Conflicts: %{_cross_os}settings-defaults(any)
 %description aws-k8s-1.34-nvidia
 %{summary}.
 
+%package aws-k8s-1.35
+Summary: Settings defaults for the aws-k8s 1.35 variants
+Requires: (%{shrink:
+           %{_cross_os}variant(aws-k8s-1.35)      or
+           %{_cross_os}variant(aws-k8s-1.35-fips)
+           %{nil}})
+Provides: %{_cross_os}settings-defaults(any)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.35)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.35-fips)
+Conflicts: %{_cross_os}settings-defaults(any)
+
+%description aws-k8s-1.35
+%{summary}.
+
+%package aws-k8s-1.35-nvidia
+Summary: Settings defaults for the aws-k8s 1.35 nvidia variants
+Requires: (%{shrink:
+           %{_cross_os}variant(aws-k8s-1.35-nvidia)      or
+           %{_cross_os}variant(aws-k8s-1.35-nvidia-fips)
+           %{nil}})
+Provides: %{_cross_os}settings-defaults(any)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.35-nvidia)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.35-nvidia-fips)
+Conflicts: %{_cross_os}settings-defaults(any)
+
+%description aws-k8s-1.35-nvidia
+%{summary}.
+
 %package metal-dev
 Summary: Settings defaults for the metal-dev variant
 Requires: %{_cross_os}variant(metal-dev)
@@ -271,6 +299,20 @@ Conflicts: %{_cross_os}settings-defaults(any)
 %description vmware-k8s-1.33
 %{summary}.
 
+%package vmware-k8s-1.35
+Summary: Settings defaults for the vmware-k8s 1.35 variants
+Requires: (%{shrink:
+           %{_cross_os}variant(vmware-k8s-1.35)      or
+           %{_cross_os}variant(vmware-k8s-1.35-fips)
+           %{nil}})
+Provides: %{_cross_os}settings-defaults(any)
+Provides: %{_cross_os}settings-defaults(vmware-k8s-1.35)
+Provides: %{_cross_os}settings-defaults(vmware-k8s-1.35-fips)
+Conflicts: %{_cross_os}settings-defaults(any)
+
+%description vmware-k8s-1.35
+%{summary}.
+
 %package vmware-k8s-1.34
 Summary: Settings defaults for the vmware-k8s 1.34 variants
 Requires: (%{shrink:
@@ -305,11 +347,14 @@ for defaults in \
   aws-k8s-1.33-nvidia \
   aws-k8s-1.34 \
   aws-k8s-1.34-nvidia \
+  aws-k8s-1.35 \
+  aws-k8s-1.35-nvidia \
   metal-dev \
   vmware-dev \
   vmware-k8s-1.32 \
   vmware-k8s-1.33 \
   vmware-k8s-1.34 \
+  vmware-k8s-1.35 \
   ;
 do
   projects+=( "-p" "settings-defaults-$(echo "${defaults}" | sed -e 's,\.,_,g')" )
@@ -343,11 +388,14 @@ for defaults in \
   aws-k8s-1.33-nvidia \
   aws-k8s-1.34 \
   aws-k8s-1.34-nvidia \
+  aws-k8s-1.35 \
+  aws-k8s-1.35-nvidia \
   metal-dev \
   vmware-dev \
   vmware-k8s-1.32 \
   vmware-k8s-1.33 \
   vmware-k8s-1.34 \
+  vmware-k8s-1.35 \
   ;
 do
   crate="$(echo "${defaults}" | sed -e 's,\.,_,g')"
@@ -414,6 +462,14 @@ done
 %{_cross_defaultsdir}/aws-k8s-1.34-nvidia.toml
 %{_cross_tmpfilesdir}/storewolf-defaults-aws-k8s-1.34-nvidia.conf
 
+%files aws-k8s-1.35
+%{_cross_defaultsdir}/aws-k8s-1.35.toml
+%{_cross_tmpfilesdir}/storewolf-defaults-aws-k8s-1.35.conf
+
+%files aws-k8s-1.35-nvidia
+%{_cross_defaultsdir}/aws-k8s-1.35-nvidia.toml
+%{_cross_tmpfilesdir}/storewolf-defaults-aws-k8s-1.35-nvidia.conf
+
 %files metal-dev
 %{_cross_defaultsdir}/metal-dev.toml
 %{_cross_tmpfilesdir}/storewolf-defaults-metal-dev.conf
@@ -433,3 +489,7 @@ done
 %files vmware-k8s-1.34
 %{_cross_defaultsdir}/vmware-k8s-1.34.toml
 %{_cross_tmpfilesdir}/storewolf-defaults-vmware-k8s-1.34.conf
+
+%files vmware-k8s-1.35
+%{_cross_defaultsdir}/vmware-k8s-1.35.toml
+%{_cross_tmpfilesdir}/storewolf-defaults-vmware-k8s-1.35.conf

--- a/packages/settings-plugins/settings-plugins.spec
+++ b/packages/settings-plugins/settings-plugins.spec
@@ -82,6 +82,8 @@ Provides: %{_cross_os}settings-plugin(aws-k8s-1.33)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.33-fips)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.34)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.34-fips)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.35)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.35-fips)
 Conflicts: %{_cross_os}settings-plugin(any)
 Conflicts: %{_cross_os}variant-flavor(nvidia)
 
@@ -105,6 +107,8 @@ Provides: %{_cross_os}settings-plugin(aws-k8s-1.33-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.33-nvidia-fips)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.34-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.34-nvidia-fips)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.35-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.35-nvidia-fips)
 Conflicts: %{_cross_os}settings-plugin(any)
 
 %description aws-k8s-nvidia
@@ -146,6 +150,8 @@ Provides: %{_cross_os}settings-plugin(vmware-k8s-1.33)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.33-fips)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.34)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.34-fips)
+Provides: %{_cross_os}settings-plugin(vmware-k8s-1.35)
+Provides: %{_cross_os}settings-plugin(vmware-k8s-1.35-fips)
 Conflicts: %{_cross_os}settings-plugin(any)
 
 %description vmware-k8s

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1902,6 +1902,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-defaults-aws-k8s-1_35"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-defaults-helper",
+]
+
+[[package]]
+name = "settings-defaults-aws-k8s-1_35-nvidia"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-defaults-helper",
+]
+
+[[package]]
 name = "settings-defaults-metal-dev"
 version = "0.1.0"
 dependencies = [
@@ -1938,6 +1952,13 @@ dependencies = [
 
 [[package]]
 name = "settings-defaults-vmware-k8s-1_34"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-defaults-helper",
+]
+
+[[package]]
+name = "settings-defaults-vmware-k8s-1_35"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-defaults-helper",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -26,12 +26,15 @@ members = [
     "settings-defaults/aws-k8s-1.33-nvidia",
     "settings-defaults/aws-k8s-1.34",
     "settings-defaults/aws-k8s-1.34-nvidia",
+    "settings-defaults/aws-k8s-1.35",
+    "settings-defaults/aws-k8s-1.35-nvidia",
     "settings-defaults/metal-dev",
     "settings-defaults/metal-k8s-1.30",
     "settings-defaults/vmware-dev",
     "settings-defaults/vmware-k8s-1.32",
     "settings-defaults/vmware-k8s-1.33",
     "settings-defaults/vmware-k8s-1.34",
+    "settings-defaults/vmware-k8s-1.35",
 
     # (all previous migrations archived; add new ones after this line)
     "settings-migrations/v1.34.0/kubelet-device-plugins-mig-settings",

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "settings-defaults-aws-k8s-1_35-nvidia"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+build = "../build-defaults.rs"
+
+[lib]
+path = "../defaults-toml.rs"
+
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/10-defaults.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/15-aws-tuf.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/20-aws-host-containers.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/20-aws-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-host-containers.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/25-cf-signal.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/26-aws-autoscaling.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/30-metrics.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/31-send-metrics-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/50-kubernetes-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/50-kubernetes-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/51-kubernetes-containerd-nvidia.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/51-kubernetes-containerd-nvidia.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-containerd-nvidia.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/52-kubernetes-services.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/52-kubernetes-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-services.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-external-cloud-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/55-kubernetes-aws-credential-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/55-kubernetes-aws-credential-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-credential-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/56-kubernetes-seccomp-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/56-kubernetes-seccomp-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-seccomp-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/57-kubernetes-device-ownership-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/57-kubernetes-device-ownership-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-device-ownership-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/58-kubernetes-graceful-shutdown.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/58-kubernetes-graceful-shutdown.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-graceful-shutdown.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/60-lockdown-none.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/60-lockdown-none.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-none.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/70-oci-hooks.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/75-oci-defaults-containerd-cri.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/75-oci-defaults-containerd-cri.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/76-oci-defaults-capabilities.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/76-oci-defaults-capabilities.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-capabilities.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri-resource-limits.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-container-toolkit.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/82-nvidia-k8s-device-plugin-cdi.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/82-nvidia-k8s-device-plugin-cdi.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin-cdi.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/90-boot.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/90-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/sources/settings-defaults/aws-k8s-1.35/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "settings-defaults-aws-k8s-1_35"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+build = "../build-defaults.rs"
+
+[lib]
+path = "../defaults-toml.rs"
+
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/10-defaults.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/15-aws-tuf.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/20-aws-host-containers.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/20-aws-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-host-containers.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/25-cf-signal.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/26-aws-autoscaling.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/30-metrics.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/31-send-metrics-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/50-kubernetes-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/50-kubernetes-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/51-kubernetes-containerd.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/51-kubernetes-containerd.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-containerd.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/52-kubernetes-services.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/52-kubernetes-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-services.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-external-cloud-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/55-kubernetes-aws-credential-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/55-kubernetes-aws-credential-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-credential-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/56-kubernetes-seccomp-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/56-kubernetes-seccomp-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-seccomp-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/57-kubernetes-device-ownership-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/57-kubernetes-device-ownership-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-device-ownership-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/58-kubernetes-graceful-shutdown.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/58-kubernetes-graceful-shutdown.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-graceful-shutdown.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/60-lockdown-integrity.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/60-lockdown-integrity.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-integrity.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/70-oci-hooks.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/75-oci-defaults-containerd-cri.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/75-oci-defaults-containerd-cri.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/76-oci-defaults-capabilities.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/76-oci-defaults-capabilities.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-capabilities.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri-resource-limits.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/90-boot.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/90-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/Cargo.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "settings-defaults-vmware-k8s-1_35"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+build = "../build-defaults.rs"
+
+[lib]
+path = "../defaults-toml.rs"
+
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/10-defaults.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/15-public-tuf.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/15-public-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-tuf.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/20-public-host-containers.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/20-public-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-host-containers.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/21-public-bootstrap-containers.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/21-public-bootstrap-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-bootstrap-containers.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/30-metrics.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/31-send-metrics.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/31-send-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-global.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/50-kubernetes-vmware.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/50-kubernetes-vmware.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-vmware.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/51-kubernetes-containerd.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/51-kubernetes-containerd.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-containerd.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/52-kubernetes-services.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/52-kubernetes-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-services.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/54-kubernetes-seccomp-default-true.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/54-kubernetes-seccomp-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-seccomp-default-true.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/55-kubernetes-device-ownership-default-true.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/55-kubernetes-device-ownership-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-device-ownership-default-true.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/60-lockdown-integrity.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/60-lockdown-integrity.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-integrity.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/70-public-ntp.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/70-public-ntp.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-ntp.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/75-oci-defaults-containerd-cri.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/75-oci-defaults-containerd-cri.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/76-oci-defaults-capabilities.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/76-oci-defaults-capabilities.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-capabilities.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri-resource-limits.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/80-oci-hooks.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/80-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/90-boot.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/90-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/variants/README.md
+++ b/variants/README.md
@@ -134,13 +134,6 @@ It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazo
 
 This variant is compatible with Kubernetes 1.33, 1.34, 1.35 and 1.36 clusters.
 
-### aws-k8s-1.34: Kubernetes 1.34 node
-
-The [aws-k8s-1.34](aws-k8s-1.34/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
-It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
-
-This variant is compatible with Kubernetes 1.34, 1.35, 1.36 and 1.37 clusters.
-
 ### aws-k8s-1.33-nvidia: Kubernetes 1.33 NVIDIA node
 
 The [aws-k8s-1.33-nvidia](aws-k8s-1.33-nvidia/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
@@ -157,6 +150,13 @@ It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazo
 
 This variant is compatible with Kubernetes 1.33, 1.34, 1.35 and 1.36 clusters.
 
+### aws-k8s-1.34: Kubernetes 1.34 node
+
+The [aws-k8s-1.34](aws-k8s-1.34/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
+It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
+
+This variant is compatible with Kubernetes 1.34, 1.35, 1.36 and 1.37 clusters.
+
 ### aws-k8s-1.34-nvidia: Kubernetes 1.34 NVIDIA node
 
 The [aws-k8s-1.34-nvidia](aws-k8s-1.34-nvidia/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
@@ -172,6 +172,29 @@ It also includes the required packages to configure containers to leverage NVIDI
 It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
 
 This variant is compatible with Kubernetes 1.34, 1.35, 1.36 and 1.37 clusters.
+
+### aws-k8s-1.35: Kubernetes 1.35 node
+
+The [aws-k8s-1.35](aws-k8s-1.35/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
+It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
+
+This variant is compatible with Kubernetes 1.35, 1.36, 1.37 and 1.38 clusters.
+
+### aws-k8s-1.35-nvidia: Kubernetes 1.35 NVIDIA node
+
+The [aws-k8s-1.35-nvidia](aws-k8s-1.35-nvidia/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
+It also includes the required packages to configure containers to leverage NVIDIA GPUs.
+It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
+
+This variant is compatible with Kubernetes 1.35, 1.36, 1.37 and 1.38 clusters.
+
+### aws-k8s-1.35-nvidia-fips: Kubernetes 1.35 NVIDIA FIPS node
+
+The [aws-k8s-1.35-nvidia-fips](aws-k8s-1.35-nvidia-fips/Cargo.toml) variant includes the packages needed to run a Kubernetes node in AWS.
+It also includes the required packages to configure containers to leverage NVIDIA GPUs and is FIPS-enabled.
+It supports self-hosted clusters and clusters managed by [EKS](https://aws.amazon.com/eks/).
+
+This variant is compatible with Kubernetes 1.35, 1.36, 1.37 and 1.38 clusters.
 
 ### aws-ecs-2: Amazon ECS container instance
 
@@ -265,6 +288,13 @@ The [vmware-k8s-1.34](vmware-k8s-1.34/Cargo.toml) variant includes the packages 
 It supports self-hosted clusters.
 
 This variant is compatible with Kubernetes 1.34, 1.35, 1.36, and 1.37 clusters.
+
+## vmware-k8s-1.35: VMware Kubernetes 1.35 node
+
+The [vmware-k8s-1.35](vmware-k8s-1.35/Cargo.toml) variant includes the packages needed to run a Kubernetes worker node as a VMware guest.
+It supports self-hosted clusters.
+
+This variant is compatible with Kubernetes 1.35, 1.36, 1.37, and 1.38 clusters.
 
 ### metal-dev: Metal development build
 

--- a/variants/aws-k8s-1.35-fips/Cargo.toml
+++ b/variants/aws-k8s-1.35-fips/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+# This is the aws-k8s-1.35-fips variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_35-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+fips = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release-swap",
+    "kernel-6.12",
+    "containerd-2.1",
+    "systemd-257",
+    "nftables",
+    "whippet",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.35",
+    "aws-iam-authenticator",
+    "soci-snapshotter",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.35-fips/amispec.toml
+++ b/variants/aws-k8s-1.35-fips/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/aws-k8s-1.35-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.35-nvidia-fips/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+# This is the aws-k8s-1.35-nvidia-fips variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_35-nvidia-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+fips = true
+
+[package.metadata.build-variant]
+included-packages = [
+    # core
+    "release-swap",
+    "kernel-6.12",
+    "containerd-2.1",
+    "systemd-257",
+    "nftables",
+    "whippet",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.35",
+    "aws-iam-authenticator",
+    "soci-snapshotter",
+    # nvidia
+    "nvidia-container-toolkit-k8s",
+    "nvidia-k8s-device-plugin",
+    "kmod-6.12-nvidia-r580-tesla",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.35-nvidia-fips/amispec.toml
+++ b/variants/aws-k8s-1.35-nvidia-fips/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/aws-k8s-1.35-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.35-nvidia/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+# This is the aws-k8s-1.35-nvidia variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_35-nvidia"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+included-packages = [
+    # core
+    "release-swap",
+    "kernel-6.12",
+    "containerd-2.1",
+    "systemd-257",
+    "nftables",
+    "whippet",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.35",
+    "aws-iam-authenticator",
+    "soci-snapshotter",
+    # nvidia
+    "nvidia-container-toolkit-k8s",
+    "nvidia-k8s-device-plugin",
+    "kmod-6.12-nvidia-r580-tesla",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.35-nvidia/amispec.toml
+++ b/variants/aws-k8s-1.35-nvidia/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/aws-k8s-1.35/Cargo.toml
+++ b/variants/aws-k8s-1.35/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+# This is the aws-k8s-1.35 variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_35"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release-swap",
+    "kernel-6.12",
+    "containerd-2.1",
+    "systemd-257",
+    "nftables",
+    "whippet",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.35",
+    "aws-iam-authenticator",
+    "soci-snapshotter",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.35/amispec.toml
+++ b/variants/aws-k8s-1.35/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/vmware-k8s-1.35-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.35-fips/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+# This is the vmware-k8s-1.35 variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_35-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+fips = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    # core
+    "release-swap",
+    "kernel-6.12",
+    "containerd-2.1",
+    "systemd-257",
+    "nftables",
+    "whippet",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.35",
+    "soci-snapshotter",
+    # vmware
+    "open-vm-tools",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.35-fips/template.ovf
+++ b/variants/vmware-k8s-1.35-fips/template.ovf
@@ -1,0 +1,1 @@
+../shared/template-unified-secboot.ovf

--- a/variants/vmware-k8s-1.35/Cargo.toml
+++ b/variants/vmware-k8s-1.35/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+# This is the vmware-k8s-1.35 variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_35"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    # core
+    "release-swap",
+    "kernel-6.12",
+    "containerd-2.1",
+    "systemd-257",
+    "nftables",
+    "whippet",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.35",
+    "soci-snapshotter",
+    # vmware
+    "open-vm-tools",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.35/template.ovf
+++ b/variants/vmware-k8s-1.35/template.ovf
@@ -1,0 +1,1 @@
+../shared/template-unified-secboot.ovf


### PR DESCRIPTION
Related to: #4725

**Description of changes:**
- Add k8s-1.35 variants
- For the 1.35 we are also using `release-swap` as default. See https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/590#issue-3241123844 for more details. This enables **zram-backed** swap to improve system stability in low-memory situations.

**Related PRs:**
- Core Kit: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/792

**Test done**
- [x] Tested launching the aws-k8s-1.35 variant with cgroupv1. Settings in the nodegroup is as below
```yaml
bottlerocket:
  settings:
    boot:
      reboot-to-reconcile: true
      kernel-parameters:
        systemd.unified_cgroup_hierarchy: ["0"]
        SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE: ["1"]
```
Node joined the cluster
```
» k get nodes
NAME                                            STATUS   ROLES    AGE     VERSION
ip-192-168-159-171.us-west-2.compute.internal   Ready    <none>   8m16s   v1.35.0-eks-ac2d5a0
```

deployed sample pods for testing and it works fine
```
» k run test --image=nginx --restart=Never
pod/test created

» k get pods
NAME   READY   STATUS    RESTARTS   AGE
test   1/1     Running   0          3m43s
```
- [x] Verified zram swap is correctly enabled on aws-k8s-1.35:

```bash
bash-5.1# swapon --show
NAME       TYPE       SIZE USED PRIO
/dev/zram0 partition 1024M   0B 1024

bash-5.1# cat /sys/block/zram0/comp_algorithm
[lz4]

bash-5.1# free -h
              total        used        free      shared  buff/cache   available
Mem:           7.6Gi       790Mi       3.7Gi       2.5Mi       3.3Gi       6.8Gi
Swap:          1.0Gi          0B       1.0Gi

bash-5.1# systemctl list-units | grep -i swap
 prepare-swap.service 
 dev-zram0.swap
 swap.target
```
- More intensive testing can be seen here - https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/792



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
