### PR TITLE
Update kernel kit to 4.7.1

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "0LNg8ap1LAvV4sVA7/cpCCbLnR3HI5IbZHFr6ugJrC0="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "4.7.0"
+version = "4.7.1"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v4.7.0"
-digest = "UluYWWn4ytDigk/uCFYUWLIJ7pB1Dmz9wV8O3LzGCK0="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v4.7.1"
+digest = "+iBHhekVVER58JhyEFs3aSGdYb2D55lG6vVgNvXm9A0="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "4.7.0"
+version = "4.7.1"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION

**Description of changes:**
Update to use the kernel kit 4.7.1


**Testing done:**
Ran cargo make to ensure twoliter can use the new kernel kit.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
