### PR TITLE
Update bottlerocket containers and move host containers to AL2023 based versions

### DIFF
--- a/sources/shared-defaults/aws-bootstrap-container.toml
+++ b/sources/shared-defaults/aws-bootstrap-container.toml
@@ -1,4 +1,4 @@
 [metadata.settings.bootstrap-containers.source.setting-generator]
-command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-bootstrap:v0.2.9'"
+command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-bootstrap:v0.2.10'"
 strength = "weak"
 depth = 1

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -3,7 +3,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source.setting-generator]
-command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.12.5'"
+command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.20.0'"
 strength = "weak"
 
 [metadata.settings.host-containers.admin.user-data]

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -14,5 +14,5 @@ enabled = true
 superpowered = false
 
 [metadata.settings.host-containers.control.source.setting-generator]
-command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.8.11'"
+command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.20.0'"
 strength = "weak"

--- a/sources/shared-defaults/public-bootstrap-containers.toml
+++ b/sources/shared-defaults/public-bootstrap-containers.toml
@@ -1,4 +1,4 @@
 [metadata.settings.bootstrap-containers.source.setting-generator]
-command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-bootstrap:v0.2.9'"
+command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-bootstrap:v0.2.10'"
 strength = "weak"
 depth = 1

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -8,7 +8,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source.setting-generator]
-command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-admin:v0.12.5'"
+command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-admin:v0.20.0'"
 strength = "weak"
 
 [settings.host-containers.control]

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -16,5 +16,5 @@ enabled = false
 superpowered = false
 
 [metadata.settings.host-containers.control.source.setting-generator]
-command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-control:v0.8.11'"
+command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-control:v0.20.0'"
 strength = "weak"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#4739

**Description of changes:**

Updated admin-container, control-container and bootstrap-container versions.
* Admin container is updated to v0.20.0
* Control container is updated to v0.20.0
* Bootstrap container is updated to v0.2.10

**Testing done:**

```
[ssm-user@control]$ apiclient get settings.host-containers
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": false,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.20.0",
        "superpowered": true,
        "user-data": xxxxxx
      },
      "control": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.20.0",
        "superpowered": false
      }
    }
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
