### PR TITLE
Add in changes to support MPS settings

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.53.0"
+version = "1.54.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -453,3 +453,7 @@ version = "1.53.0"
 ]
 "(1.51.0, 1.52.0)" = []
 "(1.52.0, 1.53.0)" = []
+"(1.53.0, 1.54.0)" = [
+    "migrate_v1.54.0_kubelet-device-plugins-mps-settings.lz4",
+    "migrate_v1.54.0_kubelet-device-plugins-mps-prefix-settings.lz4"
+]

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -3,21 +3,21 @@ project-vendor = "Bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.66.0"
+version = "0.70.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.66.0"
-digest = "0LNg8ap1LAvV4sVA7/cpCCbLnR3HI5IbZHFr6ugJrC0="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.70.0"
+digest = "8ndrJE5YUkGs4lLbnEwmWeQ69TyLYhf7QEOCvPb2kg4="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "4.7.1"
+version = "4.8.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v4.7.1"
-digest = "+iBHhekVVER58JhyEFs3aSGdYb2D55lG6vVgNvXm9A0="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v4.8.0"
+digest = "TQj66uec7F0/UBjWG/Z8+Wm1pz1MADRcdptWEQaN2S0="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "12.2.0"
+version = "12.3.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v12.2.0"
-digest = "3r2Iq3DCVaXO019LnP9pgobbO1a7N8tXdHqokupBWRM="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v12.3.0"
+digest = "B3Y0OvCiLSajOHsjbIPGsaxs2xOriA8S/nvP/b5zIF4="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "1.53.0"
+release-version = "1.54.0"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]
@@ -7,15 +7,15 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.66.0"
+version = "0.70.0"
 vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "4.7.1"
+version = "4.8.0"
 vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "12.2.0"
+version = "12.3.0"
 vendor = "bottlerocket"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1130,6 +1130,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubelet-device-plugins-mps-prefix-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "kubelet-device-plugins-mps-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+ "serde_json",
+]
+
+[[package]]
 name = "kubelet-setting-container-log-single-process-oom-kill"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-defaults-helper"
 version = "0.1.1"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "snafu",
  "toml",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "darling",
  "quote",
@@ -324,7 +324,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-modeled-types"
 version = "0.13.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "serde",
  "serde_plain",
@@ -369,7 +369,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -393,8 +393,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.17.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+version = "0.20.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -434,7 +434,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-plugin"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "abi_stable",
  "bottlerocket-settings-derive",
@@ -446,7 +446,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -459,7 +459,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "serde",
 ]
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1967,7 +1967,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1993,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2007,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2046,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2075,7 +2075,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2101,7 +2101,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-image-verifier-plugins"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2127,7 +2127,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2140,7 +2140,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2152,8 +2152,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubernetes"
-version = "0.6.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+version = "0.9.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2180,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2206,7 +2206,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2219,7 +2219,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2246,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2259,7 +2259,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2272,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -53,6 +53,8 @@ members = [
     "settings-migrations/v1.51.0/kubernetes-ecr-credential-provider-patterns",
     "settings-migrations/v1.51.0/kubernetes-additional-settings",
     "settings-migrations/v1.51.0/kubernetes-beta-cpu-manager-policy-options",
+    "settings-migrations/v1.54.0/kubelet-device-plugins-mps-settings",
+    "settings-migrations/v1.54.0/kubelet-device-plugins-mps-prefix-settings",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -122,27 +122,27 @@ walkdir = "2"
 
 [workspace.dependencies.bottlerocket-defaults-helper]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.17.0"
+tag = "bottlerocket-settings-models-v0.20.0"
 version = "0.1.1"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.17.0"
+tag = "bottlerocket-settings-models-v0.20.0"
 version = "0.13.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.17.0"
-version = "0.17.0"
+tag = "bottlerocket-settings-models-v0.20.0"
+version = "0.20.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.17.0"
+tag = "bottlerocket-settings-models-v0.20.0"
 version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.17.0"
+tag = "bottlerocket-settings-models-v0.20.0"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/settings-migrations/v1.54.0/kubelet-device-plugins-mps-prefix-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.54.0/kubelet-device-plugins-mps-prefix-settings/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kubelet-device-plugins-mps-prefix-settings"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.54.0/kubelet-device-plugins-mps-prefix-settings/src/main.rs
+++ b/sources/settings-migrations/v1.54.0/kubelet-device-plugins-mps-prefix-settings/src/main.rs
@@ -1,0 +1,18 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new settings for configuring NVIDIA MPS (Multi-Process Service)
+/// GPU sharing in the device plugin, remove the prefix for these settings
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubelet-device-plugins.nvidia.mps",
+    ]))
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}

--- a/sources/settings-migrations/v1.54.0/kubelet-device-plugins-mps-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.54.0/kubelet-device-plugins-mps-settings/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "kubelet-device-plugins-mps-settings"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true
+serde_json.workspace = true

--- a/sources/settings-migrations/v1.54.0/kubelet-device-plugins-mps-settings/src/main.rs
+++ b/sources/settings-migrations/v1.54.0/kubelet-device-plugins-mps-settings/src/main.rs
@@ -1,0 +1,39 @@
+use migration_helpers::{migrate, Migration, MigrationData, Result};
+use std::process;
+
+const DEVICE_SHARING_STRATEGY_SETTING: &str =
+    "settings.kubelet-device-plugins.nvidia.device-sharing-strategy";
+
+pub struct ReplaceDeviceSharingStrategy;
+
+impl Migration for ReplaceDeviceSharingStrategy {
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        println!("ReplaceDeviceSharingStrategy has no work to do on upgrade.");
+        Ok(input)
+    }
+
+    fn backward(&mut self, mut input: MigrationData) -> Result<MigrationData> {
+        if let Some(data) = input.data.get_mut(DEVICE_SHARING_STRATEGY_SETTING) {
+            if let serde_json::Value::String(s) = data {
+                if s == "mps" {
+                    *data = serde_json::Value::String("none".to_string());
+                    println!("Changed device-sharing-strategy from 'mps' to 'none' on downgrade.");
+                }
+            }
+        }
+        Ok(input)
+    }
+}
+
+/// We added new enum variant for configuring NVIDIA MPS (Multi-Process Service)
+/// GPU sharing in the device plugin.
+fn run() -> Result<()> {
+    migrate(ReplaceDeviceSharingStrategy)
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/nvidia-k8s-device-plugin.toml
+++ b/sources/shared-defaults/nvidia-k8s-device-plugin.toml
@@ -1,10 +1,22 @@
 # nvidia device plugin service
 [services.nvidia-k8s-device-plugin]
-restart-commands = ["/bin/systemctl try-reload-or-restart nvidia-k8s-device-plugin.service"]
+restart-commands = [
+    "/bin/systemctl try-reload-or-restart nvidia-k8s-device-plugin.service",
+]
 configuration-files = [
     "nvidia-k8s-device-plugin-conf",
     "nvidia-k8s-device-plugin-exec-start-conf",
-    "nvidia-k8s-device-plugin-mig-conf"
+    "nvidia-k8s-device-plugin-mig-conf",
+]
+
+[services.nvidia-mps-control-daemon]
+restart-commands = [
+    "/bin/systemctl try-reload-or-restart nvidia-mps-control-daemon.service",
+]
+configuration-files = [
+    "nvidia-k8s-device-plugin-conf",
+    "nvidia-mps-control-daemon-exec-start-conf",
+    "nvidia-k8s-device-plugin-mig-conf",
 ]
 
 [configuration-files.nvidia-k8s-device-plugin-conf]
@@ -19,11 +31,19 @@ template-path = "/usr/share/templates/nvidia-k8s-device-plugin-exec-start-conf"
 path = "/etc/nvidia-migmanager/nvidia-migmanager.toml"
 template-path = "/usr/share/templates/nvidia-k8s-device-plugin-mig-conf"
 
+[configuration-files.nvidia-mps-control-daemon-exec-start-conf]
+path = "/etc/systemd/system/nvidia-mps-control-daemon.service.d/exec-start.conf"
+template-path = "/usr/share/templates/nvidia-mps-control-daemon-exec-start-conf"
+
 [metadata.settings.kubelet-device-plugins.nvidia]
-affected-services = ["nvidia-k8s-device-plugin", "nvidia-container-toolkit"]
+affected-services = [
+    "nvidia-k8s-device-plugin",
+    "nvidia-container-toolkit",
+    "nvidia-mps-control-daemon",
+]
 
 [settings.kubelet-device-plugins.nvidia]
 pass-device-specs = true
-device-id-strategy="index"
-device-sharing-strategy="none"
-device-partitioning-strategy="none"
+device-id-strategy = "index"
+device-sharing-strategy = "none"
+device-partitioning-strategy = "none"


### PR DESCRIPTION
**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket/issues/4673

**Description of changes:**
Update the shared defaults configuration files and services to accomodate the `nvidia-mps-control-daemon`. Add a migration for the new settings.

**Testing done:**
`cargo make` completes. For full testing of the feature, look at https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/789


Migration testing passed.

From the console when downgrading:
```
         Starting Write network status...
[  OK  ] Finished Prepare Containerd Directory (/var/lib/containerd).
[    5.718341] migrator[1537]: 22:11:30 [INFO] Running migration 'migrate_v1.54.0_kubelet-device-plugins-mps-prefix-settings.lz4'
[  OK  ] Finished Prepare Kubelet Directory (/var/lib/kubelet).
[  OK  ] Finished Prepare Opt Directory (/opt).
[  OK  ] Finished Prepare Var Directory (/var).
[  OK  ] Finished Write network status.
[  OK  ] Reached target Network is Online.
         Mounting CNI Plugin Directory (/opt/cni)...
[    5.977593] migrator[1537]: 22:11:31 [INFO] Running migration 'migrate_v1.54.0_kubelet-device-plugins-mps-settings.lz4'
[    6.070127] migrator[1537]: 22:11:31 [INFO] Removing the weak settings and metadata.
         Mounting CSI Helper Directory (/opt/csi)...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
