### PR TITLE
disable in-place updates for dev variants

### DIFF
--- a/sources/settings-defaults/aws-dev/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-dev/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-dev/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-dev/defaults.d/11-updates.toml
@@ -1,1 +1,0 @@
-../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-dev/defaults.d/15-aws-tuf.toml
+++ b/sources/settings-defaults/aws-dev/defaults.d/15-aws-tuf.toml
@@ -1,1 +1,0 @@
-../../../shared-defaults/aws-tuf.toml

--- a/sources/settings-defaults/aws-ecs-2-nvidia/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-ecs-2-nvidia/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-ecs-2/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-ecs-2/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-ecs-3-nvidia/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-ecs-3-nvidia/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-ecs-3/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-ecs-3/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-k8s-1.31/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-k8s-1.31/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-k8s-1.32-nvidia/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-k8s-1.32-nvidia/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-k8s-1.32/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-k8s-1.32/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/metal-dev/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/metal-dev/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/metal-dev/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/metal-dev/defaults.d/11-updates.toml
@@ -1,1 +1,0 @@
-../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/metal-dev/defaults.d/15-public-tuf.toml
+++ b/sources/settings-defaults/metal-dev/defaults.d/15-public-tuf.toml
@@ -1,1 +1,0 @@
-../../../shared-defaults/public-tuf.toml

--- a/sources/settings-defaults/metal-k8s-1.30/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/metal-k8s-1.30/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/vmware-dev/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/vmware-dev/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/vmware-dev/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/vmware-dev/defaults.d/11-updates.toml
@@ -1,1 +1,0 @@
-../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/vmware-dev/defaults.d/15-public-tuf.toml
+++ b/sources/settings-defaults/vmware-dev/defaults.d/15-public-tuf.toml
@@ -1,1 +1,0 @@
-../../../shared-defaults/public-tuf.toml

--- a/sources/settings-defaults/vmware-k8s-1.32/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/vmware-k8s-1.32/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-plugins/aws-dev/src/lib.rs
+++ b/sources/settings-plugins/aws-dev/src/lib.rs
@@ -5,7 +5,6 @@ use bottlerocket_settings_plugin::SettingsPlugin;
 #[model(rename = "settings", impl_default = true)]
 struct AwsDevSettings {
     motd: bottlerocket_settings_models::MotdV1,
-    updates: bottlerocket_settings_models::UpdatesSettingsV1,
     host_containers: bottlerocket_settings_models::HostContainersSettingsV1,
     bootstrap_commands: bottlerocket_settings_models::BootstrapCommandsSettingsV1,
     bootstrap_containers: bottlerocket_settings_models::BootstrapContainersSettingsV1,

--- a/sources/settings-plugins/metal-dev/src/lib.rs
+++ b/sources/settings-plugins/metal-dev/src/lib.rs
@@ -5,7 +5,6 @@ use bottlerocket_settings_plugin::SettingsPlugin;
 #[model(rename = "settings", impl_default = true)]
 struct MetalDevSettings {
     motd: bottlerocket_settings_models::MotdV1,
-    updates: bottlerocket_settings_models::UpdatesSettingsV1,
     host_containers: bottlerocket_settings_models::HostContainersSettingsV1,
     bootstrap_commands: bottlerocket_settings_models::BootstrapCommandsSettingsV1,
     bootstrap_containers: bottlerocket_settings_models::BootstrapContainersSettingsV1,

--- a/sources/settings-plugins/vmware-dev/src/lib.rs
+++ b/sources/settings-plugins/vmware-dev/src/lib.rs
@@ -5,7 +5,6 @@ use bottlerocket_settings_plugin::SettingsPlugin;
 #[model(rename = "settings", impl_default = true)]
 struct VmwareDevSettings {
     motd: bottlerocket_settings_models::MotdV1,
-    updates: bottlerocket_settings_models::UpdatesSettingsV1,
     host_containers: bottlerocket_settings_models::HostContainersSettingsV1,
     bootstrap_commands: bottlerocket_settings_models::BootstrapCommandsSettingsV1,
     bootstrap_containers: bottlerocket_settings_models::BootstrapContainersSettingsV1,

--- a/sources/shared-defaults/defaults.toml
+++ b/sources/shared-defaults/defaults.toml
@@ -40,32 +40,6 @@ affected-services = ["containerd"]
 configuration-files = ["proxy-env"]
 restart-commands = ["/bin/systemctl try-restart host-containerd.service"]
 
-# Updates.
-
-[settings.updates]
-version-lock = "latest"
-ignore-waves = false
-
-[services.thar-be-updates]
-configuration-files = ["thar-be-updates-toml"]
-restart-commands = []
-
-[services.updog]
-configuration-files = ["updog-toml"]
-restart-commands = []
-
-[configuration-files.thar-be-updates-toml]
-path = "/etc/thar-be-updates.toml"
-template-path = "/usr/share/templates/thar-be-updates-toml"
-
-[configuration-files.updog-toml]
-path = "/etc/updog.toml"
-template-path = "/usr/share/templates/updog-toml"
-
-[metadata.settings.updates]
-affected-services = ["updog", "thar-be-updates"]
-seed.setting-generator = "bork seed"
-
 # HostContainers
 
 [services.host-containers]
@@ -90,7 +64,7 @@ path = "/etc/network/proxy.env"
 template-path = "/usr/share/templates/proxy-env"
 
 [metadata.settings.network]
-affected-services = ["containerd", "host-containerd", "host-containers", "updog"]
+affected-services = ["containerd", "host-containerd", "host-containers"]
 
 [metadata.settings.network.hostname]
 affected-services = ["hostname", "hosts"]

--- a/sources/shared-defaults/updates.toml
+++ b/sources/shared-defaults/updates.toml
@@ -1,0 +1,31 @@
+# Updates settings.
+
+[settings.updates]
+version-lock = "latest"
+ignore-waves = false
+
+[services.thar-be-updates]
+configuration-files = ["thar-be-updates-toml"]
+restart-commands = []
+
+[services.updog]
+configuration-files = ["updog-toml"]
+restart-commands = []
+
+[configuration-files.thar-be-updates-toml]
+path = "/etc/thar-be-updates.toml"
+template-path = "/usr/share/templates/thar-be-updates-toml"
+
+[configuration-files.updog-toml]
+path = "/etc/updog.toml"
+template-path = "/usr/share/templates/updog-toml"
+
+[metadata.settings.updates]
+affected-services = ["updog", "thar-be-updates"]
+seed.setting-generator = "bork seed"
+
+# Updog config has proxy servers and needs to be regenerated if those network
+# settings change.
+
+[metadata.settings.network]
+affected-services = ["containerd", "host-containerd", "host-containers", "updog"]

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -15,6 +15,7 @@ systemd-networkd = true
 erofs-root-partition = true
 external-kmod-development = false
 encrypted-storage = true
+in-place-updates = false
 
 [package.metadata.build-variant]
 kernel-parameters = [

--- a/variants/metal-dev/Cargo.toml
+++ b/variants/metal-dev/Cargo.toml
@@ -16,6 +16,7 @@ xfs-data-partition = true
 erofs-root-partition = true
 uefi-secure-boot = true
 systemd-networkd = true
+in-place-updates = false
 
 [package.metadata.build-variant]
 image-format = "raw"

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -18,6 +18,7 @@ systemd-networkd = true
 erofs-root-partition = true
 external-kmod-development = false
 encrypted-storage = true
+in-place-updates = false
 
 [package.metadata.build-variant]
 image-format = "vmdk"


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Split updates-related defaults into a separate file included by all variants.

Adjust feature flags, defaults, and plugin for `*-dev` to disable in-place updates and remove all implicit references to that functionality.

This simplifies testing for variants that don't support in-place updates.


**Testing done:**
Built `aws-dev`. Verified that it booted correctly and that no updates-related settings were available.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
