### PR TITLE
add registries helper to shared defaults

### DIFF
--- a/sources/shared-defaults/defaults.toml
+++ b/sources/shared-defaults/defaults.toml
@@ -213,3 +213,12 @@ template-path = "/usr/share/templates/netdog-toml"
 [configuration-files.certdog-toml]
 path = "/etc/certdog.toml"
 template-path = "/usr/share/templates/certdog-toml"
+
+# thar-be-registries - renders hosts.toml files for containerd registry config
+[services.thar-be-registries]
+configuration-files = ["thar-be-registries-toml"]
+restart-commands = ["/usr/bin/thar-be-registries"]
+
+[configuration-files.thar-be-registries-toml]
+path = "/etc/containerd/thar-be-registries.toml"
+template-path = "/usr/share/templates/thar-be-registries-toml"

--- a/sources/shared-defaults/docker-services.toml
+++ b/sources/shared-defaults/docker-services.toml
@@ -9,12 +9,12 @@ template-path = "/usr/share/templates/docker-daemon-json"
 # Image registries. Retained for backwards compatibility, but superseded by the
 # more specific metadata for mirrors and credentials.
 [metadata.settings.container-registry]
-affected-services = ["docker", "host-containers", "bootstrap-containers"]
+affected-services = ["docker", "host-containers", "bootstrap-containers", "thar-be-registries"]
 
 # Image registry mirrors
 [metadata.settings.container-registry.mirrors]
-affected-services = ["docker", "host-containers", "bootstrap-containers"]
+affected-services = ["docker", "host-containers", "bootstrap-containers", "thar-be-registries"]
 
 # Image registry credentials
 [metadata.settings.container-registry.credentials]
-affected-services = ["host-containers", "bootstrap-containers"]
+affected-services = ["host-containers", "bootstrap-containers", "thar-be-registries"]

--- a/sources/shared-defaults/ecs.toml
+++ b/sources/shared-defaults/ecs.toml
@@ -26,4 +26,4 @@ affected-services = ["containerd", "docker", "ecs", "host-containerd", "host-con
 
 # Image registry credentials
 [metadata.settings.container-registry.credentials]
-affected-services = ["ecs", "host-containers", "bootstrap-containers"]
+affected-services = ["ecs", "host-containers", "bootstrap-containers", "thar-be-registries"]

--- a/sources/shared-defaults/kubernetes-containerd-nvidia.toml
+++ b/sources/shared-defaults/kubernetes-containerd-nvidia.toml
@@ -4,7 +4,7 @@ template-path = "/usr/share/templates/containerd-config-toml_k8s_nvidia_containe
 
 # Image registries
 [metadata.settings.container-registry]
-affected-services = ["containerd", "host-containers", "bootstrap-containers", "soci-snapshotter"]
+affected-services = ["containerd", "host-containers", "bootstrap-containers", "soci-snapshotter", "thar-be-registries"]
 
 [configuration-files.snapshotter-toml]
 path = "/etc/containerd/config.d/001-snapshotter.toml"

--- a/sources/shared-defaults/kubernetes-containerd.toml
+++ b/sources/shared-defaults/kubernetes-containerd.toml
@@ -4,7 +4,7 @@ template-path = "/usr/share/templates/containerd-config-toml_k8s_containerd_sock
 
 # Image registries
 [metadata.settings.container-registry]
-affected-services = ["containerd", "host-containers", "bootstrap-containers", "soci-snapshotter"]
+affected-services = ["containerd", "host-containers", "bootstrap-containers", "soci-snapshotter", "thar-be-registries"]
 
 [configuration-files.snapshotter-toml]
 path = "/etc/containerd/config.d/001-snapshotter.toml"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes: https://github.com/bottlerocket-os/bottlerocket/issues/1963
Requires: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/819

**Description of changes:**
Integrate `thar-be-registries` into shared defaults, so it runs whenever container registry settings change.


**Testing done:**
See testing in related PRs.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
