### PR TITLE
release: kernel-kit v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Suppress IPv6 on interfaces with no IPv6 intent in `net.toml` ([bottlerocket-core-kit#826])
 
 ## OS Changes
-* Update `bottlerocket-kernel-kit` from 4.8.2 to 5.0.0 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/blob/develop/CHANGELOG.md#v500-2026-02-19) ([commits](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/compare/v4.8.2...v5.0.0)) ([#4764])
+* Update `bottlerocket-kernel-kit` from 4.8.2 to 5.0.1 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/blob/develop/CHANGELOG.md#v501-2026-02-26) ([commits](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/compare/v4.8.2...v5.0.1)) ([#4764], [#4775])
 * Update `bottlerocket-core-kit` from 13.0.0 to 13.1.0 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/develop/CHANGELOG.md#v1310-2026-02-25) ([commits](https://github.com/bottlerocket-os/bottlerocket-core-kit/compare/v13.0.0...v13.1.0)) ([#4770])
 
 ## Build Changes
@@ -19,6 +19,7 @@
 [#4767]: https://github.com/bottlerocket-os/bottlerocket/pull/4767
 [#4770]: https://github.com/bottlerocket-os/bottlerocket/pull/4770
 [#4773]: https://github.com/bottlerocket-os/bottlerocket/pull/4773
+[#4775]: https://github.com/bottlerocket-os/bottlerocket/pull/4775
 [bottlerocket-core-kit#819]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/819
 [bottlerocket-core-kit#820]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/820
 [bottlerocket-core-kit#826]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/826

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "8ndrJE5YUkGs4lLbnEwmWeQ69TyLYhf7QEOCvPb2kg4="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.0.0"
+version = "5.0.1"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.0.0"
-digest = "F67tvJ3xXm07DwBNTMfPxrpujTqj+rAC+aTJtCH8kMo="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.0.1"
+digest = "0da2D/aLHDvYzL2lbczeSGx2NphMukKUPMunpGPWBFY="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.0.0"
+version = "5.0.1"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
- Bump kernel-kit to v5.0.1
- Update changelog for the new kernel-kit


**Testing done:**

- Built an AMI and validated that it booted and joined a cluster

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
