### PR TITLE
twoliter: bump kernel kit to v5.0.2

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "8ndrJE5YUkGs4lLbnEwmWeQ69TyLYhf7QEOCvPb2kg4="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.0.1"
+version = "5.0.2"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.0.1"
-digest = "0da2D/aLHDvYzL2lbczeSGx2NphMukKUPMunpGPWBFY="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.0.2"
+digest = "Vf4vhu1ghN2FnR2CdoEKaBeEfPVKaF8Y4e55XyO4e6g="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.0.1"
+version = "5.0.2"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
**Description of changes:**
- Update kernel-kit to v5.0.2


**Testing done:**
- See GH Actions


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
