### PR TITLE
Use dedicated kubelet env configuration for k8s 1.35 NVIDIA variants

### DIFF
--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/59-kubernetes-kubelet-env-nvidia.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/59-kubernetes-kubelet-env-nvidia.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-kubelet-env-nvidia.toml

--- a/sources/shared-defaults/kubernetes-kubelet-env-nvidia.toml
+++ b/sources/shared-defaults/kubernetes-kubelet-env-nvidia.toml
@@ -1,0 +1,2 @@
+[configuration-files.kubelet-env]
+template-path = "/usr/share/templates/kubelet-env-nvidia"


### PR DESCRIPTION
**Issue number:**

Related to: https://github.com/bottlerocket-os/bottlerocket/issues/4756

**Description of changes:**

Use the dedicated kubelet env configuration file for Kubernetes 1.35 NVIDIA variants.

**Testing done:**

In combination with https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/860:

```fish
❯ if k get nodes --show-labels | rg -q nvidia.com;
   echo "Label present"
end

Label present
``` 

Also, I confirmed that the other default values were respected:

```bash
[ssm-user@control]$ apiclient get settings.kubernetes.seccomp
{
  "settings": {
    "kubernetes": {
      "seccomp-default": true
    }
  }
}
[ssm-user@control]$
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
