### PR TITLE
fix: reserve EKS add-on ports via ip_local_reserved_ports sysctl

### DIFF
--- a/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/58-kubernetes-eks-sysctl.toml
+++ b/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/58-kubernetes-eks-sysctl.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-eks-sysctl.toml

--- a/sources/settings-defaults/aws-k8s-1.31/defaults.d/58-kubernetes-eks-sysctl.toml
+++ b/sources/settings-defaults/aws-k8s-1.31/defaults.d/58-kubernetes-eks-sysctl.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-eks-sysctl.toml

--- a/sources/settings-defaults/aws-k8s-1.32-nvidia/defaults.d/58-kubernetes-eks-sysctl.toml
+++ b/sources/settings-defaults/aws-k8s-1.32-nvidia/defaults.d/58-kubernetes-eks-sysctl.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-eks-sysctl.toml

--- a/sources/settings-defaults/aws-k8s-1.32/defaults.d/58-kubernetes-eks-sysctl.toml
+++ b/sources/settings-defaults/aws-k8s-1.32/defaults.d/58-kubernetes-eks-sysctl.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-eks-sysctl.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/58-kubernetes-eks-sysctl.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/58-kubernetes-eks-sysctl.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-eks-sysctl.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/58-kubernetes-eks-sysctl.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/58-kubernetes-eks-sysctl.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-eks-sysctl.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/58-kubernetes-eks-sysctl.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/58-kubernetes-eks-sysctl.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-eks-sysctl.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/58-kubernetes-eks-sysctl.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/58-kubernetes-eks-sysctl.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-eks-sysctl.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/58-kubernetes-eks-sysctl.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/58-kubernetes-eks-sysctl.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-eks-sysctl.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/58-kubernetes-eks-sysctl.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/58-kubernetes-eks-sysctl.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-eks-sysctl.toml

--- a/sources/shared-defaults/kubernetes-eks-sysctl.toml
+++ b/sources/shared-defaults/kubernetes-eks-sysctl.toml
@@ -1,0 +1,18 @@
+# Reserve ports used by EKS add-ons running with hostNetwork=true.
+# This prevents containerd's CRI streaming server (stream_server_port=0) from
+# grabbing these ports via ephemeral/dynamic assignment, which would cause
+# add-on pods to fail to bind and enter CrashLoopBackOff.
+#
+# Note: ip_local_reserved_ports only blocks ephemeral port assignment.
+# Processes that explicitly bind to these ports are unaffected.
+#
+#   2703  - EKS Pod Identity Agent (health/liveness probe server)
+#   9808  - Amazon EBS CSI Driver node plugin (health check)
+#   9809  - Amazon EFS CSI Driver node plugin (health check)
+#  10249  - kube-proxy (metrics)
+#  10250  - kubelet (API server)
+#  10256  - kube-proxy (health check)
+#  61678  - Amazon VPC CNI / aws-node (Prometheus metrics)
+#  61679  - Amazon VPC CNI / aws-node (introspection endpoint)
+[settings.kernel.sysctl]
+"net/ipv4/ip_local_reserved_ports" = "2703,9808,9809,10249,10250,10256,61678,61679"

--- a/sources/shared-defaults/kubernetes-eks-sysctl.toml
+++ b/sources/shared-defaults/kubernetes-eks-sysctl.toml
@@ -15,4 +15,4 @@
 #  61678  - Amazon VPC CNI / aws-node (Prometheus metrics)
 #  61679  - Amazon VPC CNI / aws-node (introspection endpoint)
 [settings.kernel.sysctl]
-"net/ipv4/ip_local_reserved_ports" = "2703,9808,9809,10249,10250,10256,61678,61679"
+"net.ipv4.ip_local_reserved_ports" = "2703,9808,9809,10249,10250,10256,61678,61679"


### PR DESCRIPTION
  Reserve well-known ports used by EKS add-ons with hostNetwork=true via net.ipv4.ip_local_reserved_ports sysctl, preventing containerd's CRI streaming server from grabbing   
  them via dynamic ephemeral assignment.                                                                                                                                       
                                                                                                                                                                               
  Issue number:                                                                                                                                                                
                  
  Closes #4783

  Description of changes:

  Containerd's CRI streaming server uses stream_server_port=0, causing the kernel to assign any available ephemeral port. When that port collides with one required by an EKS  
  add-on pod running with hostNetwork: true, the pod fails to bind and enters CrashLoopBackOff.
                                                                                                                                                                               
  Observed in production on a Bottlerocket node:                                                                                                                               
  - Port 2703 (eks-pod-identity-agent health check) was grabbed by containerd → eks-pod-identity-agent crashed                                                                                                                                  → VPC CNI crashed as it could not retreive credentials → aws-node crashed → Node went NotReady                                                                                                                                                       
                        
  This PR adds sources/shared-defaults/kubernetes-eks-sysctl.toml which configures net.ipv4.ip_local_reserved_ports via settings.kernel.sysctl. Symlinks are added to all      
  aws-k8s-* variant defaults.d/ directories at position 58- (between 57-kubernetes-device-ownership and 60-lockdown-integrity).                                                
                                                                                                                                                                               
  Note: net.ipv4.ip_local_reserved_ports only blocks ephemeral port assignment. Processes that explicitly bind to these ports (add-on pods, kubelet, kube-proxy) are completely
   unaffected. The sysctl is applied by corndog sysctl at boot, before containerd starts.
                                                                                                                                                                               
  Ports reserved: 
                                                                                                                                                                               
| Port  | Component                                          |
| ----- | -------------------------------------------------- |
| 2703  | EKS Pod Identity Agent (health/liveness probe)     |
| 9808  | Amazon EBS CSI Driver node plugin (health check)   |
| 9809  | Amazon EFS CSI Driver node plugin (health check)   |
| 10249 | kube-proxy (metrics)                               |
| 10250 | kubelet (API server)                               |
| 10256 | kube-proxy (health check)                          |
| 61678 | Amazon VPC CNI / aws-node (Prometheus metrics)     |
| 61679 | Amazon VPC CNI / aws-node (introspection endpoint) |

  Testing done:                                                                                                                                                                
   
  - cargo make check passed — format, lints, clippy, shell, and migration checks all clean                                                                                     
  - Verified TOML syntax of the new shared defaults file
  - Verified symlinks exist in all 10 aws-k8s-* variant defaults.d/ directories at position 58-                                                                                
  - Port list verified against official EKS add-on manifests — only add-ons confirmed to use hostNetwork: true are included
  
If I have missed anything or if there are improvements needed — whether in the approach or implementation — please do guide me. Happy to iterate on this. 
                                                                                                                                                                               
  Terms of contribution:
                                                                                                                                                                               
  By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license. 