### PR TITLE
chore(aws-k8s): support authenticated dualstack ecr public pulls

### DIFF
--- a/sources/shared-defaults/kubernetes-aws-credential-provider.toml
+++ b/sources/shared-defaults/kubernetes-aws-credential-provider.toml
@@ -18,4 +18,5 @@ image-patterns = [
     "*.dkr.ecr.*.csp.hci.ic.gov",
     "*.dkr.ecr-fips.*.csp.hci.ic.gov",
     "public.ecr.aws",
+    "ecr-public.aws.com",
 ]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A, but related to
- https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/876
- https://github.com/awslabs/amazon-eks-ami/issues/2592

**Description of changes:**

This updates the default credential provider configuration to support authentication for `ecr-public.aws.com`, which is the dualstack endpoint for ECR public. 

Though the version of the `ecr-credential-provider` included in the AMI may not support this authentication, or the node role may allow getting a public token, this is a safe change as `kubelet` always falls back to unauthenticated pulls if all credential providers fail. Releases are not yet cut with this change for 1.29-1.31, but the change is in their corresponding release branches.

**Testing done:**

This was previously tested by Yutong for IPv4: https://github.com/bottlerocket-os/bottlerocket/issues/4396#issuecomment-2752461604



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
