### PR TITLE
twoliter: bump kernel kit to v5.3.1 and core kit to v14.0.0

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "989HgnsGWp0HyNmcoMK7oQHYYaJdTCtWiu/xok2H1+M="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.2.0"
+version = "5.3.1"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.2.0"
-digest = "O2YvfFm9hamiGKD490rQTBRvI7BspNRIdK7rPtzoktY="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.3.1"
+digest = "qO1bKI8m62lpXxoWF3FJOjCqn4rQwGWyCJWQw4JZg5E="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -17,7 +17,7 @@ digest = "qO1bKI8m62lpXxoWF3FJOjCqn4rQwGWyCJWQw4JZg5E="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "13.3.0"
+version = "14.0.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v13.3.0"
-digest = "BXmrQPCQdTGBh+TD0qBAglbi5gv3nqaJBSZESg5tMdQ="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v14.0.0"
+digest = "dA0aTiTjcT1jCmt/DVJUNeAXM1YvVXenPu98+wYENrA="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -17,5 +17,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "13.3.0"
+version = "14.0.0"
 vendor = "bottlerocket"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.2.0"
+version = "5.3.1"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
**Description of changes:**
- bump kernel kit to v5.3.1
- bump core kit to v14.0.0

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
