### PR TITLE
Bump to Containerd 2.2 on all containerd 2.1 variants

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -465,5 +465,6 @@ version = "1.60.0"
 "(1.57.0, 1.58.0)" = []
 "(1.58.0, 1.59.0)" = []
 "(1.59.0, 1.60.0)" = [
-    "migrate_v1.60.0_kubernetes-topology-manager-policy-options.lz4"
+    "migrate_v1.60.0_kubernetes-topology-manager-policy-options.lz4",
+    "migrate_v1.60.0_container-runtime-max-concurrent-unpacks.lz4",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -626,6 +626,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "container-runtime-max-concurrent-unpacks"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "container-runtime-plugins-settings"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "settings-migrations/v1.54.0/kubelet-device-plugins-mps-prefix-settings",
     "settings-migrations/v1.56.0/image-verifier-plugins-extensible",
     "settings-migrations/v1.60.0/kubernetes-topology-manager-policy-options",
+    "settings-migrations/v1.60.0/container-runtime-max-concurrent-unpacks",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/settings-migrations/v1.60.0/container-runtime-max-concurrent-unpacks/Cargo.toml
+++ b/sources/settings-migrations/v1.60.0/container-runtime-max-concurrent-unpacks/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "container-runtime-max-concurrent-unpacks"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.60.0/container-runtime-max-concurrent-unpacks/src/main.rs
+++ b/sources/settings-migrations/v1.60.0/container-runtime-max-concurrent-unpacks/src/main.rs
@@ -1,0 +1,21 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new container-runtime setting for:
+/// - max_concurrent_unpacks
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.container-runtime.max-concurrent-unpacks",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -31,7 +31,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.18",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3-fips/Cargo.toml
+++ b/variants/aws-ecs-3-fips/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3-nvidia-fips/Cargo.toml
+++ b/variants/aws-ecs-3-nvidia-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3-nvidia/Cargo.toml
+++ b/variants/aws-ecs-3-nvidia/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3/Cargo.toml
+++ b/variants/aws-ecs-3/Cargo.toml
@@ -21,7 +21,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.30-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.30-nvidia-fips/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.31-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.31-nvidia-fips/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.32-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.32-nvidia-fips/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.33-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.1",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
 # k8s
     "cni",

--- a/variants/aws-k8s-1.33-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia-fips/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.33-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.33/Cargo.toml
+++ b/variants/aws-k8s-1.33/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
 # k8s
     "cni",

--- a/variants/aws-k8s-1.34-fips/Cargo.toml
+++ b/variants/aws-k8s-1.34-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.34-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.34-nvidia-fips/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.34-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.34-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.34/Cargo.toml
+++ b/variants/aws-k8s-1.34/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35-fips/Cargo.toml
+++ b/variants/aws-k8s-1.35-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.35-nvidia-fips/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.35-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35/Cargo.toml
+++ b/variants/aws-k8s-1.35/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.33-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.33-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
     # k8s
     "cni",

--- a/variants/vmware-k8s-1.33/Cargo.toml
+++ b/variants/vmware-k8s-1.33/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
     # k8s
     "cni",

--- a/variants/vmware-k8s-1.34-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.34-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.34/Cargo.toml
+++ b/variants/vmware-k8s-1.34/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.35-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.35-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.35/Cargo.toml
+++ b/variants/vmware-k8s-1.35/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",


### PR DESCRIPTION
**Issue number:**

Related https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/806

**Description of changes:**

Introduce containerd 2.2 for all variants currently on `containerd 2.1` (27 total). Also adds the `container-runtime.max-concurrent-unpacks` settings migration.

**Variants bumped to containerd 2.2:**

AWS K8s:
- `aws-k8s-1.30-nvidia-fips`
- `aws-k8s-1.31-nvidia-fips`
- `aws-k8s-1.32-nvidia-fips`
- `aws-k8s-1.33`, `aws-k8s-1.33-fips`, `aws-k8s-1.33-nvidia`, `aws-k8s-1.33-nvidia-fips`
- `aws-k8s-1.34`, `aws-k8s-1.34-fips`, `aws-k8s-1.34-nvidia`, `aws-k8s-1.34-nvidia-fips`
- `aws-k8s-1.35`, `aws-k8s-1.35-fips`, `aws-k8s-1.35-nvidia`, `aws-k8s-1.35-nvidia-fips`

AWS ECS:
- `aws-ecs-3`, `aws-ecs-3-fips`, `aws-ecs-3-nvidia`, `aws-ecs-3-nvidia-fips`

VMware K8s:
- `vmware-k8s-1.33`, `vmware-k8s-1.33-fips`
- `vmware-k8s-1.34`, `vmware-k8s-1.34-fips`
- `vmware-k8s-1.35`, `vmware-k8s-1.35-fips`

Dev:
- `aws-dev`, `vmware-dev`

The setting is opt-in only — no default value is applied. Users who want to tune concurrent unpacks can explicitly set it via `apiclient set container-runtime.max-concurrent-unpacks=<value>`.

Depends on:
- https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/886 — containerd 2.2 package, template exposure, and warning infrastructure
- https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/119 — `max_concurrent_unpacks` field in `ContainerRuntimeSettingsV1`

**Testing done:**

Conformance tested containerd 2.2 across 20 variant/arch combinations — all passing.

| Test | Containerd 2.2 variant | Containerd 2.1 variant |
|------|----------------------|------------------------|
| Setting rendered in config | `max_concurrent_unpacks = 5` ✅ | Not rendered ✅ |


### Migration Testing (v1.59.0 → v1.60.0)

Built a custom TUF repo and tested upgrade/downgrade on `aws-k8s-1.35` (x86_64) on an EKS 1.35 cluster.

**Before upgrade (v1.59.0):** containerd 2.1, setting does not exist in the model.

```
bash-5.2# containerd --version
containerd github.com/containerd/containerd/v2 2.1.6+bottlerocket c74fd8780002eb26bd5940ae339d690d891221c2
```

```
bash-5.2# apiclient get os
{
 "os": {
 "arch": "x86_64",
 "build_id": "73b3be44",
 "pretty_name": "Bottlerocket OS 1.59.0 (aws-k8s-1.35)",
 "variant_id": "aws-k8s-1.35",
 "version_id": "1.59.0"
 }
}
bash-5.2# apiclient set settings.container-runtime.max-concurrent-unpacks=4
Failed to change settings: Failed PATCH request to '/settings/keypair?tx=apiclient-set-YqaRzPE6ntefoKmt': Status 400 when PATCHing /settings/keypair?tx=apiclient-set-YqaRzPE6ntefoKmt: Unable to match your input to the data model. We may not have enough type information. Please try the --json input form. Cause: Error during deserialization: unknown field `max-concurrent-unpacks`, expected one of `max-container-log-line-size`, `max-concurrent-downloads`, `concurrent-download-chunk-size`, `concurrent-layer-fetch-buffer`, `enable-unprivileged-ports`, `enable-unprivileged-icmp`, `snapshotter` at line 1 column 46
```

**After upgrade (v1.60.0):** containerd 2.2, setting is available and functional.

```
bash-5.2# containerd --version
containerd github.com/containerd/containerd/v2 2.2.2+bottlerocket 301b2dac98f15c27117da5c8af12118a041a31d9
```

```
bash-5.2# apiclient get os
{
 "os": {
 "arch": "x86_64",
 "build_id": "a68d6de8-dirty",
 "pretty_name": "Bottlerocket OS 1.60.0 (aws-k8s-1.35)",
 "variant_id": "aws-k8s-1.35",
 "version_id": "1.60.0"
 }
}
bash-5.2# apiclient set settings.container-runtime.max-concurrent-unpacks=4
bash-5.2# apiclient get settings.container
{
 "settings": {
 "container-runtime": {
 "max-concurrent-unpacks": 4
 }
 }
}
```

**Containerd config reflects the setting:**

```
bash-5.2# cat /etc/containerd/config.toml | grep max_concurrent_unpacks -C 5
[plugins."io.containerd.cri.v1.runtime"]
device_ownership_from_security_context = true
enable_selinux = true

[plugins."io.containerd.transfer.v1.local"]
max_concurrent_unpacks = 4
concurrent_layer_fetch_buffer = 0

[[plugins."io.containerd.transfer.v1.local".unpack_config]]
snapshotter = "overlayfs"
differ = "walking"
```

**After downgrade (signpost rollback-to-inactive):** Setting is cleanly removed.

```
bash-5.2# apiclient get settings.container
{}
```

```
[plugins."io.containerd.transfer.v1.local"]
concurrent_layer_fetch_buffer = 0
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
