### PR TITLE
Update to kernel-kit v5.3.2

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "989HgnsGWp0HyNmcoMK7oQHYYaJdTCtWiu/xok2H1+M="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.3.1"
+version = "5.3.2"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.3.1"
-digest = "qO1bKI8m62lpXxoWF3FJOjCqn4rQwGWyCJWQw4JZg5E="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.3.2"
+digest = "Zx2XRVVWU3vD8VqPpirArqlG+gu7nUZuw7SydjQj85M="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.3.1"
+version = "5.3.2"
 vendor = "bottlerocket"
 
 [[kit]]

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -30,7 +30,7 @@ kernel-parameters = [
 included-packages = [
 # core
     "release",
-    "kernel-6.12",
+    "kernel-6.18",
     "containerd-2.1",
     "systemd-257",
     "nftables",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
-  Update Bottlerocket to use the latest kernet-kit
- Also update the `aws-dev` variant to use the 6.18 kernel

**Testing done:**
- Built and booted the `aws-dev` variant

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
