### PR TITLE
k8s: reduce nf_conntrack_tcp_timeout_syn_sent to 20s on AWS variants

### DIFF
--- a/sources/shared-defaults/kubernetes-aws.toml
+++ b/sources/shared-defaults/kubernetes-aws.toml
@@ -35,3 +35,13 @@ template-path = "/usr/share/templates/warm-pool-wait-toml"
 
 [metadata.settings.autoscaling]
 affected-services = ["autoscaling-warm-pool"]
+
+# Reduce nf_conntrack_tcp_timeout_syn_sent from the kernel default of 120s to 20s.
+# On AWS with VPC CNI, pod IPs can be reassigned within the default 30s cooldown after
+# a pod crash or force-kill. Stale SYN_SENT conntrack entries from in-flight connections
+# at crash time persist for 120s by default — beyond the cooldown window. If a client
+# retries with the same src IP:port after the IP is reused by a different pod/service,
+# the stale entry misdirects traffic even after kube-proxy has updated routing rules.
+# Setting this to 20s ensures entries expire before the minimum IP reuse window.
+[settings.kernel.sysctl]
+"net/netfilter/nf_conntrack_tcp_timeout_syn_sent" = "20"


### PR DESCRIPTION
## Problem

In Kubernetes clusters using VPC CNI, pod IPs can be reassigned within the **default 30s cooldown window** after a pod crash or force-kill. Stale `SYN_SENT` conntrack entries from in-flight connections at crash time persist for **120 seconds** by default — well beyond the cooldown period.

If a client retries with the same `src_ip:src_port` tuple after the IP has been reassigned to a different pod (potentially a different service), the stale entry misdirects the connection **even after kube-proxy has updated iptables/ipvs/nftables rules**.

```
t=0      Pod A crashes (SIGKILL / no preStop hook)
t=0-2s   In-flight SYNs create SYN_SENT conntrack entries (dst = old pod IP)
t=2s     kube-proxy updates iptables — correct routing restored
t=30s    VPC CNI may reassign the IP to Pod B (different service)
t=0-120s Stale SYN_SENT entry still valid — client retry hits Pod B instead
```

## Fix

Add `net.netfilter.nf_conntrack_tcp_timeout_syn_sent = 20` to `kubernetes-aws.toml`, which is included by all `aws-k8s-*` variants.

**Why 20 seconds:**
- Below the VPC CNI 30s IP cooldown — closes the race window
- Covers ~3 SYN retransmissions (Linux backoff: 1s, 3s, 7s...)
- Consistent with fast-churn ephemeral pod workloads on AWS

## Verification

```bash
sysctl net.netfilter.nf_conntrack_tcp_timeout_syn_sent
# net.netfilter.nf_conntrack_tcp_timeout_syn_sent = 20
```