### PR TITLE
Add settings.kubernetes.feature-gates to configure kubelet feature gates

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.59.0"
+version = "1.60.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -464,3 +464,6 @@ version = "1.59.0"
 "(1.56.0, 1.57.0)" = []
 "(1.57.0, 1.58.0)" = []
 "(1.58.0, 1.59.0)" = []
+"(1.59.0, 1.60.0)" = [
+    "migrate_v1.60.0_kubernetes-feature-gates.lz4",
+]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "settings-migrations/v1.54.0/kubelet-device-plugins-mps-settings",
     "settings-migrations/v1.54.0/kubelet-device-plugins-mps-prefix-settings",
     "settings-migrations/v1.56.0/image-verifier-plugins-extensible",
+    "settings-migrations/v1.60.0/kubernetes-feature-gates",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/settings-migrations/v1.60.0/kubernetes-feature-gates/Cargo.toml
+++ b/sources/settings-migrations/v1.60.0/kubernetes-feature-gates/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kubernetes-feature-gates"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.60.0/kubernetes-feature-gates/src/main.rs
+++ b/sources/settings-migrations/v1.60.0/kubernetes-feature-gates/src/main.rs
@@ -1,0 +1,24 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added `settings.kubernetes.feature-gates` to allow users to enable or
+/// disable kubelet feature gates. Individual gates are stored as sub-keys
+/// (e.g. `settings.kubernetes.feature-gates.MemoryQoS = true`). We don't
+/// want to enumerate all possible gate names, so we remove the whole prefix
+/// when downgrading to a version that doesn't know about this setting.
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kubernetes.feature-gates",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
## Problem

Bottlerocket currently has no way to configure kubelet feature gates. Users on AL2023 can modify `/etc/kubernetes/kubelet/kubelet-config.json` directly in `userData`, but Bottlerocket's immutable filesystem makes this impossible. The only supported path is the settings API.

This has been a long-standing gap: see #1702 (open since 2021), #2481, and #4056.

A concrete use case: enabling `MemoryQoS=true` on Spark/data workloads to enforce cgroup v2 `memory.high` throttling and prevent OOM kills, as described in the [AWS Data on EKS best practices](https://awslabs.github.io/data-on-eks/docs/bestpractices/analytics/spark-oom-kills). Bottlerocket already runs with cgroup v2 — the only missing piece is the feature gate.

## Proposed setting

```toml
[settings.kubernetes.feature-gates]
MemoryQoS = true
TopologyManager = true
```

Individual gates are stored as sub-keys, following the same pattern as `settings.kubernetes.eviction-hard`. The value type is `bool` to match how kubelet's `KubeletConfiguration.featureGates` field is defined (`map[string]bool`).

## This PR

This PR contains the **datastore migration** in the `bottlerocket` repo:

- `sources/settings-migrations/v1.60.0/kubernetes-feature-gates/` — uses `AddPrefixesMigration`, removing unknown gate keys on downgrade (same approach as `kubelet-eviction-hard` in v1.0.8)
- `Release.toml` — adds the `(1.59.0, 1.60.0)` migration entry
- `sources/Cargo.toml` — registers the new migration crate in the workspace

## Companion changes needed

Full implementation requires changes in two other repositories:

### `bottlerocket-os/bottlerocket-settings-sdk`

Add `feature_gates` to `KubernetesSettingsV1` in the settings model:

```rust
// In the KubernetesSettingsV1 struct
#[serde(skip_serializing_if = "Option::is_none")]
pub feature_gates: Option<HashMap<String, bool>>,
```

The field name follows Bottlerocket's snake_case convention; it serializes to the `feature-gates` key in the TOML API.

### `bottlerocket-os/bottlerocket-core-kit`

Update the `kubelet-config` template to render a `featureGates` block when the setting is present:

```
{{#if settings.kubernetes.feature-gates}}
featureGates:
  {{#each settings.kubernetes.feature-gates}}
  {{@key}}: {{this}}
  {{/each}}
{{/if}}
```

(Exact template syntax depends on the templating engine used in core-kit.)

## Testing

Once all three pieces are in place, the expected behaviour:

```toml
# In userdata or via apiclient:
[settings.kubernetes.feature-gates]
MemoryQoS = true
```

Results in kubelet config containing:
```yaml
featureGates:
  MemoryQoS: true
```

And the node's cgroup v2 hierarchy setting `memory.high` based on container memory requests, with the throttling ratio from `settings.kubernetes.memory-throttling-factor`.

## Notes

- Version number (`1.60.0`) is a placeholder — happy to adjust to whatever version is next in the release cycle.
- Guidance on the preferred `bool` vs `String` value type for the SDK field would be welcome. Using `bool` seems most natural but `String` would allow future values beyond `true`/`false` if the Kubernetes API ever changes.

Closes #1702
Related: #2481, #4056