### PR TITLE
Mitigate CVE-2026-31431: blacklist algif_aead module

### DIFF
--- a/sources/settings-defaults/aws-dev/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-dev/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-ecs-2-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-ecs-2-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-ecs-2/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-ecs-2/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-ecs-3-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-ecs-3-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-ecs-3/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-ecs-3/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-k8s-1.31-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-k8s-1.31/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-k8s-1.31/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-k8s-1.32-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-k8s-1.32-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-k8s-1.32/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-k8s-1.32/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/metal-dev/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/metal-dev/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/metal-k8s-1.30/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/metal-k8s-1.30/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/vmware-dev/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/vmware-dev/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/vmware-k8s-1.32/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/vmware-k8s-1.32/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/65-cve-2026-31431-algif-aead.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/65-cve-2026-31431-algif-aead.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cve-2026-31431-algif-aead-mitigation.toml

--- a/sources/shared-defaults/cve-2026-31431-algif-aead-mitigation.toml
+++ b/sources/shared-defaults/cve-2026-31431-algif-aead-mitigation.toml
@@ -1,0 +1,9 @@
+# Mitigation for CVE-2026-31431 ("Copy Fail")
+# Blacklists the algif_aead kernel module to prevent local privilege escalation
+# via the AF_ALG socket interface's in-place AEAD decryption optimization.
+# This module is not required for normal Bottlerocket operation.
+# Reference: https://nvd.nist.gov/vuln/detail/CVE-2026-31431
+
+[settings.kernel.modules]
+"algif_aead" = { blacklist = true }
+


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to #4821

**Description of changes:**
Blacklists the algif_aead kernel module across all variants to prevent local privilege escalation via the AF_ALG socket in-place AEAD decryption optimization.

