### PR TITLE
Revert containerd-2.2 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
 # v1.60.0 (2026-04-28)
 
 ## Release Highlights
-* Update `containerd` 2.1 to 2.2 on  the following variants ([#4801]):
-  * `aws-k8s-1.30-nvidia-fips`
-  * `aws-k8s-1.31-nvidia-fips`
-  * `aws-k8s-1.33+`
-  * `aws-ecs-3-*`
-  * `vmware-k8s-1.33+`
-  * `aws-dev` and `vmware-dev`
 * Add `topology-manager-policy-options` settings (`prefer-closest-numa-nodes`, `max-allowable-numa-nodes`) ([#4778], [bottlerocket-core-kit#901])
 * Add `max-concurrent-unpacks` setting support for `containerd-2.2` ([#4801], [bottlerocket-core-kit#886])
 

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -31,7 +31,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.18",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3-fips/Cargo.toml
+++ b/variants/aws-ecs-3-fips/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3-nvidia-fips/Cargo.toml
+++ b/variants/aws-ecs-3-nvidia-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3-nvidia/Cargo.toml
+++ b/variants/aws-ecs-3-nvidia/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3/Cargo.toml
+++ b/variants/aws-ecs-3/Cargo.toml
@@ -21,7 +21,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.30-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.30-nvidia-fips/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.31-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.31-nvidia-fips/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.32-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.32-nvidia-fips/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.33-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.1",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
 # k8s
     "cni",

--- a/variants/aws-k8s-1.33-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia-fips/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.33-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.33/Cargo.toml
+++ b/variants/aws-k8s-1.33/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
 # k8s
     "cni",

--- a/variants/aws-k8s-1.34-fips/Cargo.toml
+++ b/variants/aws-k8s-1.34-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.34-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.34-nvidia-fips/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.34-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.34-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.34/Cargo.toml
+++ b/variants/aws-k8s-1.34/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35-fips/Cargo.toml
+++ b/variants/aws-k8s-1.35-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.35-nvidia-fips/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.35-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35/Cargo.toml
+++ b/variants/aws-k8s-1.35/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.33-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.33-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/vmware-k8s-1.33/Cargo.toml
+++ b/variants/vmware-k8s-1.33/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/vmware-k8s-1.34-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.34-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.34/Cargo.toml
+++ b/variants/vmware-k8s-1.34/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.35-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.35-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.35/Cargo.toml
+++ b/variants/vmware-k8s-1.35/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
- Reverts the commits that add containerd-2.2 to all variants and removes the settings-migrations
- Update the Changelog to reflect the same


**Testing done:**
- Built and launched a `k8s-1.35` AMI


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
