### PR TITLE
revert containerd-2.2 update and changelog update to v1.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,14 @@
-# v1.60.0 (2026-04-28)
+# v1.60.0 (2026-05-04)
 
 ## Release Highlights
-* Update `containerd` 2.1 to 2.2 on  the following variants ([#4801]):
-  * `aws-k8s-1.30-nvidia-fips`
-  * `aws-k8s-1.31-nvidia-fips`
-  * `aws-k8s-1.33+`
-  * `aws-ecs-3-*`
-  * `vmware-k8s-1.33+`
-  * `aws-dev` and `vmware-dev`
 * Add `topology-manager-policy-options` settings (`prefer-closest-numa-nodes`, `max-allowable-numa-nodes`) ([#4778], [bottlerocket-core-kit#901])
-* Add `max-concurrent-unpacks` setting support for `containerd-2.2` ([#4801], [bottlerocket-core-kit#886])
+
+## Security Fixes
+* Patch `kernel-6.1`, `kernel-6.12` and `kernel-6.18` to mitigate CVE-2026-31431 ([bottlerocket-kernel-kit#416])
 
 ## OS Changes
 * Update `bottlerocket-core-kit` from 14.1.0 to 14.2.0 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/develop/CHANGELOG.md#v1420) ([commits](https://github.com/bottlerocket-os/bottlerocket-core-kit/compare/v14.1.0...v14.2.0)) ([#4818])
-* Update `bottlerocket-kernel-kit` from 5.3.3 to 5.4.0 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/blob/develop/CHANGELOG.md#v540) ([commits](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/compare/v5.3.3...v5.4.0)) ([#4818])
+* Update `bottlerocket-kernel-kit` from 5.3.3 to 5.4.1 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/blob/develop/CHANGELOG.md#v541) ([commits](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/compare/v5.3.3...v5.4.1)) ([#4818] [#4824])
 * Use the 6.18 kernel for `aws-dev` variant ([#4802])
 * Update `admin-container` from 0.20.5 to 0.20.6 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-admin-container/blob/develop/CHANGELOG.md#0206) ([commits](https://github.com/bottlerocket-os/bottlerocket-admin-container/compare/v0.20.5...v0.20.6)) ([#4820])
 * Update `control-container` from 0.20.5 to 0.20.6 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-control-container/blob/develop/CHANGELOG.md#0206) ([commits](https://github.com/bottlerocket-os/bottlerocket-control-container/compare/v0.20.5...v0.20.6)) ([#4820])
@@ -32,11 +27,11 @@
 [#4765]: https://github.com/bottlerocket-os/bottlerocket/pull/4765
 [#4778]: https://github.com/bottlerocket-os/bottlerocket/pull/4778
 [#4792]: https://github.com/bottlerocket-os/bottlerocket/pull/4792
-[#4801]: https://github.com/bottlerocket-os/bottlerocket/pull/4801
 [#4802]: https://github.com/bottlerocket-os/bottlerocket/pull/4802
 [#4818]: https://github.com/bottlerocket-os/bottlerocket/pull/4818
 [#4820]: https://github.com/bottlerocket-os/bottlerocket/pull/4820
-[bottlerocket-core-kit#886]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/886
+[#4824]: https://github.com/bottlerocket-os/bottlerocket/pull/4824
+[bottlerocket-kernel-kit#416]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/416
 [bottlerocket-core-kit#896]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/896
 [bottlerocket-core-kit#901]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/901
 

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "0eWj4taxRMckHeUNLcPSAS8dYNessdJrDR1+poSjqM4="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.4.0"
+version = "5.4.1"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.4.0"
-digest = "GyFMZxHNXragPnJnoR9QY2vWZAT0UZMUMPB5f9pMF7U="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.4.1"
+digest = "vK5mD+mvbv74cflqJMKAKZMMAADx1X5gLl3fFK2UYiE="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.4.0"
+version = "5.4.1"
 vendor = "bottlerocket"
 
 [[kit]]

--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -31,7 +31,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.18",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3-fips/Cargo.toml
+++ b/variants/aws-ecs-3-fips/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3-nvidia-fips/Cargo.toml
+++ b/variants/aws-ecs-3-nvidia-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3-nvidia/Cargo.toml
+++ b/variants/aws-ecs-3-nvidia/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3/Cargo.toml
+++ b/variants/aws-ecs-3/Cargo.toml
@@ -21,7 +21,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.30-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.30-nvidia-fips/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.31-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.31-nvidia-fips/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.32-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.32-nvidia-fips/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.33-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.1",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
 # k8s
     "cni",

--- a/variants/aws-k8s-1.33-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia-fips/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.33-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.33/Cargo.toml
+++ b/variants/aws-k8s-1.33/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
 # k8s
     "cni",

--- a/variants/aws-k8s-1.34-fips/Cargo.toml
+++ b/variants/aws-k8s-1.34-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.34-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.34-nvidia-fips/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.34-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.34-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.34/Cargo.toml
+++ b/variants/aws-k8s-1.34/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35-fips/Cargo.toml
+++ b/variants/aws-k8s-1.35-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.35-nvidia-fips/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.35-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35/Cargo.toml
+++ b/variants/aws-k8s-1.35/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.33-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.33-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/vmware-k8s-1.33/Cargo.toml
+++ b/variants/vmware-k8s-1.33/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "whippet",
     # k8s
     "cni",

--- a/variants/vmware-k8s-1.34-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.34-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.34/Cargo.toml
+++ b/variants/vmware-k8s-1.34/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.35-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.35-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.35/Cargo.toml
+++ b/variants/vmware-k8s-1.35/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.2",
+    "containerd-2.1",
     "systemd-257",
     "nftables",
     "whippet",


### PR DESCRIPTION
**Description of changes:**
* Update kernel-kit to v5.4.1
* Revert containerd-2.2 update in variants

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
