### PR TITLE
twoliter: bump kernel-kit version to v5.4.2

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "0eWj4taxRMckHeUNLcPSAS8dYNessdJrDR1+poSjqM4="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.4.1"
+version = "5.4.2"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.4.1"
-digest = "vK5mD+mvbv74cflqJMKAKZMMAADx1X5gLl3fFK2UYiE="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.4.2"
+digest = "PqMz38SmZBXCS/KPuiAzu4qAawBebsmqFPafBRcvEV8="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.4.1"
+version = "5.4.2"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
twoliter: bump kernel-kit version to v5.4.2





**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
