### PR TITLE
Add containerd image verification to k8s and expand ecs-3/ecs-4 verifiers

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.62.0"
+version = "1.63.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -470,3 +470,6 @@ version = "1.62.0"
 ]
 "(1.60.0, 1.61.0)" = []
 "(1.61.0, 1.62.0)" = []
+"(1.62.0, 1.63.0)" = [
+    "migrate_v1.63.0_image-verifier-plugins-settings.lz4",
+]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "1.62.0"
+release-version = "1.63.0"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1074,6 +1074,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "image-verifier-plugins-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -63,6 +63,7 @@ members = [
     "settings-migrations/v1.56.0/image-verifier-plugins-extensible",
     "settings-migrations/v1.60.0/kubernetes-topology-manager-policy-options",
     "settings-migrations/v1.60.0/container-runtime-max-concurrent-unpacks",
+    "settings-migrations/v1.63.0/image-verifier-plugins-settings",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/aws-k8s-1.33-nvidia/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/aws-k8s-1.33/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/aws-k8s-1.33/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/aws-k8s-1.34-nvidia/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/aws-k8s-1.34/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/aws-k8s-1.34/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/aws-k8s-1.35-nvidia/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/aws-k8s-1.35/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/aws-k8s-1.35/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/aws-k8s-1.36-nvidia/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/aws-k8s-1.36-nvidia/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/aws-k8s-1.36/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/aws-k8s-1.36/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/vmware-k8s-1.33/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/vmware-k8s-1.33/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/vmware-k8s-1.34/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/vmware-k8s-1.34/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/vmware-k8s-1.35/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/vmware-k8s-1.35/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/vmware-k8s-1.36/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/vmware-k8s-1.36/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-migrations/v1.63.0/image-verifier-plugins-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.63.0/image-verifier-plugins-settings/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "image-verifier-plugins-settings"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.63.0/image-verifier-plugins-settings/src/main.rs
+++ b/sources/settings-migrations/v1.63.0/image-verifier-plugins-settings/src/main.rs
@@ -1,0 +1,50 @@
+use migration_helpers::common_migrations::{AddPrefixesMigration, NoOpMigration};
+use migration_helpers::{migrate, MigrationData, Result};
+use std::process;
+
+/// Added new image-verifier-plugins settings.
+/// For k8s variants: remove the settings on downgrade since they didn't exist before.
+/// For ecs-3 variants: no migration needed since these settings already exist.
+fn run() -> Result<()> {
+    // Create a custom migration that checks variant at runtime
+    migrate(VariantSpecificMigration)
+}
+
+struct VariantSpecificMigration;
+
+impl migration_helpers::Migration for VariantSpecificMigration {
+    fn forward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        // No work needed on upgrade for any variant
+        println!("VariantSpecificMigration has no work to do on upgrade.");
+        Ok(input)
+    }
+
+    fn backward(&mut self, input: MigrationData) -> Result<MigrationData> {
+        // Check variant from runtime data
+        if let Some(variant_value) = input.data.get("os.variant_id") {
+            if let Some(variant_str) = variant_value.as_str() {
+                if variant_str.starts_with("aws-ecs-") {
+                    // For ECS variants, no migration needed
+                    println!(
+                        "ECS variant detected ({}), no migration needed",
+                        variant_str
+                    );
+                    return NoOpMigration.backward(input);
+                }
+            }
+        }
+
+        println!("Using default behavior (remove settings on downgrade)");
+        AddPrefixesMigration(vec!["settings.image-verifier-plugins"]).backward(input)
+    }
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}

--- a/sources/settings-plugins/aws-k8s/src/lib.rs
+++ b/sources/settings-plugins/aws-k8s/src/lib.rs
@@ -24,5 +24,6 @@ struct AwsK8sSettings {
     dns: bottlerocket_settings_models::DnsSettingsV1,
     container_runtime: bottlerocket_settings_models::ContainerRuntimeSettingsV1,
     container_runtime_plugins: bottlerocket_settings_models::ContainerRuntimePluginsSettingsV1,
+    image_verifier_plugins: bottlerocket_settings_models::ImageVerifierPluginsSettingsV1,
     autoscaling: bottlerocket_settings_models::AutoScalingSettingsV1,
 }

--- a/sources/settings-plugins/vmware-k8s/src/lib.rs
+++ b/sources/settings-plugins/vmware-k8s/src/lib.rs
@@ -23,4 +23,5 @@ struct VmwareK8sSettings {
     dns: bottlerocket_settings_models::DnsSettingsV1,
     container_runtime: bottlerocket_settings_models::ContainerRuntimeSettingsV1,
     container_runtime_plugins: bottlerocket_settings_models::ContainerRuntimePluginsSettingsV1,
+    image_verifier_plugins: bottlerocket_settings_models::ImageVerifierPluginsSettingsV1,
 }

--- a/variants/aws-ecs-3-fips/Cargo.toml
+++ b/variants/aws-ecs-3-fips/Cargo.toml
@@ -33,7 +33,9 @@ included-packages = [
 # ecs
     "ecs-agent-config",
     "aws-signer-notation-plugin",
+    "digestion-image-verifier",
     "notation-image-verifier",
+    "thar-be-image-verifiers",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-ecs-3-nvidia-fips/Cargo.toml
+++ b/variants/aws-ecs-3-nvidia-fips/Cargo.toml
@@ -34,7 +34,9 @@ included-packages = [
 # ecs
     "ecs-agent-nvidia-config",
     "aws-signer-notation-plugin",
+    "digestion-image-verifier",
     "notation-image-verifier",
+    "thar-be-image-verifiers",
 # NVIDIA support
     "ecs-gpu-init",
     "nvidia-container-toolkit-ecs",

--- a/variants/aws-ecs-3-nvidia/Cargo.toml
+++ b/variants/aws-ecs-3-nvidia/Cargo.toml
@@ -33,7 +33,9 @@ included-packages = [
 # ecs
     "ecs-agent-nvidia-config",
     "aws-signer-notation-plugin",
+    "digestion-image-verifier",
     "notation-image-verifier",
+    "thar-be-image-verifiers",
 # NVIDIA support
     "ecs-gpu-init",
     "nvidia-container-toolkit-ecs",

--- a/variants/aws-ecs-3/Cargo.toml
+++ b/variants/aws-ecs-3/Cargo.toml
@@ -32,7 +32,9 @@ included-packages = [
 # ecs
     "ecs-agent-config",
     "aws-signer-notation-plugin",
+    "digestion-image-verifier",
     "notation-image-verifier",
+    "thar-be-image-verifiers",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-ecs-4-nvidia/Cargo.toml
+++ b/variants/aws-ecs-4-nvidia/Cargo.toml
@@ -33,7 +33,9 @@ included-packages = [
 # ecs
     "ecs-agent-nvidia-config",
     "aws-signer-notation-plugin",
+    "digestion-image-verifier",
     "notation-image-verifier",
+    "thar-be-image-verifiers",
 # NVIDIA support
     "ecs-gpu-init",
     "nvidia-container-toolkit-ecs",

--- a/variants/aws-ecs-4/Cargo.toml
+++ b/variants/aws-ecs-4/Cargo.toml
@@ -32,7 +32,9 @@ included-packages = [
 # ecs
     "ecs-agent-config",
     "aws-signer-notation-plugin",
+    "digestion-image-verifier",
     "notation-image-verifier",
+    "thar-be-image-verifiers",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.33-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-fips/Cargo.toml
@@ -31,6 +31,10 @@ included-packages = [
     "kubelet-1.33",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.33-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia-fips/Cargo.toml
@@ -34,6 +34,10 @@ included-packages = [
     "kubelet-1.33",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.33-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia/Cargo.toml
@@ -33,6 +33,10 @@ included-packages = [
     "kubelet-1.33",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.33/Cargo.toml
+++ b/variants/aws-k8s-1.33/Cargo.toml
@@ -30,6 +30,10 @@ included-packages = [
     "kubelet-1.33",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.34-fips/Cargo.toml
+++ b/variants/aws-k8s-1.34-fips/Cargo.toml
@@ -33,6 +33,10 @@ included-packages = [
     "kubelet-1.34",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.34-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.34-nvidia-fips/Cargo.toml
@@ -36,6 +36,10 @@ included-packages = [
     "kubelet-1.34",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.34-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.34-nvidia/Cargo.toml
@@ -35,6 +35,10 @@ included-packages = [
     "kubelet-1.34",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.34/Cargo.toml
+++ b/variants/aws-k8s-1.34/Cargo.toml
@@ -32,6 +32,10 @@ included-packages = [
     "kubelet-1.34",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.35-fips/Cargo.toml
+++ b/variants/aws-k8s-1.35-fips/Cargo.toml
@@ -33,6 +33,10 @@ included-packages = [
     "kubelet-1.35",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.35-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.35-nvidia-fips/Cargo.toml
@@ -36,6 +36,10 @@ included-packages = [
     "kubelet-1.35",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.35-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.35-nvidia/Cargo.toml
@@ -35,6 +35,10 @@ included-packages = [
     "kubelet-1.35",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.35/Cargo.toml
+++ b/variants/aws-k8s-1.35/Cargo.toml
@@ -32,6 +32,10 @@ included-packages = [
     "kubelet-1.35",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.36-fips/Cargo.toml
+++ b/variants/aws-k8s-1.36-fips/Cargo.toml
@@ -33,6 +33,10 @@ included-packages = [
     "kubelet-1.36",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/aws-k8s-1.36-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.36-nvidia-fips/Cargo.toml
@@ -36,6 +36,10 @@ included-packages = [
     "kubelet-1.36",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.36-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.36-nvidia/Cargo.toml
@@ -35,6 +35,10 @@ included-packages = [
     "kubelet-1.36",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # nvidia
     "nvidia-container-toolkit-k8s",
     "nvidia-k8s-device-plugin",

--- a/variants/aws-k8s-1.36/Cargo.toml
+++ b/variants/aws-k8s-1.36/Cargo.toml
@@ -32,6 +32,10 @@ included-packages = [
     "kubelet-1.36",
     "aws-iam-authenticator",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
 ]
 kernel-parameters = [
     "console=tty0",

--- a/variants/vmware-k8s-1.33-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.33-fips/Cargo.toml
@@ -43,6 +43,10 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.33",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.33/Cargo.toml
+++ b/variants/vmware-k8s-1.33/Cargo.toml
@@ -42,6 +42,10 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.33",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.34-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.34-fips/Cargo.toml
@@ -45,6 +45,10 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.34",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.34/Cargo.toml
+++ b/variants/vmware-k8s-1.34/Cargo.toml
@@ -44,6 +44,10 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.34",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.35-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.35-fips/Cargo.toml
@@ -45,6 +45,10 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.35",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.35/Cargo.toml
+++ b/variants/vmware-k8s-1.35/Cargo.toml
@@ -44,6 +44,10 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.35",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.36-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.36-fips/Cargo.toml
@@ -45,6 +45,10 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.36",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # vmware
     "open-vm-tools",
 ]

--- a/variants/vmware-k8s-1.36/Cargo.toml
+++ b/variants/vmware-k8s-1.36/Cargo.toml
@@ -44,6 +44,10 @@ included-packages = [
     "cni-plugins",
     "kubelet-1.36",
     "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
     # vmware
     "open-vm-tools",
 ]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #4684

**Description of changes:**

  - Add image verification settings for k8s-1.33, k8s-1.34, and k8s-1.35 variants
  - Add image verification packages `aws-signer-notation-plugin`, `digestion-image-verifier`, `notation-image-verifier`, and `bottlerocket-thar-be-image-verifiers`, in k8s-1.33, k8s-1.34, and k8s-1.35 variants
  - Add `digestion-image-verifier` and `thar-be-image-verifiers` in ecs-3 variants
  - Add custom migration for image-verifier-plugins settings so that migration only applies to k8s variants

Pending #4827 to add these packages and settings for the new k8s-1.36 variants

**Testing done:**

k8s testing performed on:

```
{
  "os": {
    "arch": "x86_64",
    "build_id": "3adeb5d4",
    "pretty_name": "Bottlerocket OS 1.60.0 (aws-k8s-1.34)",
    "variant_id": "aws-k8s-1.34",
    "version_id": "1.60.0"
  }
}
```

ecs-3 testing performed on:

```
bash-5.2# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "3adeb5d4",
    "pretty_name": "Bottlerocket OS 1.60.0 (aws-ecs-3)",
    "variant_id": "aws-ecs-3",
    "version_id": "1.60.0"
  }
}
```

- [x] notation verifier on k8s

<details>

Trust policy that allows signed image `public.ecr.aws/o7o0w6s5/public-alpine-clone:latest`:

```
bash-5.2# apiclient get settings.image
{
  "settings": {
    "image-verifier-plugins": {
      "enabled": true,
      "notation": {
        "trustpolicy": "ewogICAidmVyc2lvbiI6IjEuMCIsCiAgICJ0cnVzdFBvbGljaWVzIjpbCiAgICAgIHsKICAgICAgICAgIm5hbWUiOiJhd3Mtc2lnbmVyLXRwIiwKICAgICAgICAgInJlZ2lzdHJ5U2NvcGVzIjpbCiAgICAgICAgICAgICIqIgogICAgICAgICBdLAogICAgICAgICAic2lnbmF0dXJlVmVyaWZpY2F0aW9uIjp7CiAgICAgICAgICAgICJsZXZlbCI6InN0cmljdCIsCgkJCSJvdmVycmlkZSI6IHsKICAgICAgICAgICAgICAicmV2b2NhdGlvbiI6ICJza2lwIgoJCQl9CiAgICAgICAgIH0sCiAgICAgICAgICJ0cnVzdFN0b3JlcyI6WwogICAgICAgICAgICAic2lnbmluZ0F1dGhvcml0eTphd3Mtc2lnbmVyLXRzIiwKICAgICAgICAgICAgInNpZ25pbmdBdXRob3JpdHk6YXdzLXVzLWdvdi1zaWduZXItdHMiCiAgICAgICAgIF0sCiAgICAgICAgICJ0cnVzdGVkSWRlbnRpdGllcyI6WwogICAgICAgICAgICAiYXJuOmF3czpzaWduZXI6dXMtd2VzdC0yOjQ1ODM1ODk2MjIyNDovc2lnbmluZy1wcm9maWxlcy9ub3RhdGlvbl90ZXN0IiwKICAgICAgICAgICAgImFybjphd3MtdXMtZ292OnNpZ25lcjp1cy1nb3Ytd2VzdC0xOjI3ODMwODIxMTQzMDovc2lnbmluZy1wcm9maWxlcy9ub3RhdGlvbl90ZXN0IgogICAgICAgICBdCiAgICAgIH0KICAgXQp9Cg=="
      }
    }
  }
}
```

Test 3 cases: 1/ pull the signed image (allow), 2/ pull an unsigned image (deny) 3/ pull an image with a different signature not explicitly allowed in the trustpolicy (deny):

```
bash-5.2# ctr i pull public.ecr.aws/o7o0w6s5/public-alpine-clone:latest
...
Pulling from OCI Registry (public.ecr.aws/o7o0w6s5/public-alpine-clone:latest)  elapsed: 2.3 s  total:  3.6 Mi  (1.6 MiB/

bash-5.2# ctr i pull docker.io/library/hello-world:latest
ctr: image verifier bindir blocked pull of docker.io/library/hello-world:latest with digest sha256:f9078146db2e05e794366b1bfe584a14ea6317f44027d10ef7dad65279026885 for reason: verifier notation-image-verifier rejected image (exit code 1): image verification failed: Error: signature verification failed: no signature is associated with "docker.io/library/hello-world@sha256:f9078146db2e05e794366b1bfe584a14ea6317f44027d10ef7dad65279026885", make sure the artifact was signed successfully

bash-5.2# ctr i pull public.ecr.aws/o7o0w6s5/public-nginx-clone:latest
ctr: image verifier bindir blocked pull of public.ecr.aws/o7o0w6s5/public-nginx-clone:latest with digest sha256:bd1578eec775d0b28fd7f664b182b7e1fb75f1dd09f92d865dababe8525dfe8b for reason: verifier notation-image-verifier rejected image (exit code 1): image verification failed: Error: signature verification failedfor all the signatures associated with public.ecr.aws/o7o0w6s5/public-nginx-clone@sha256:bd1578eec775d0b28fd7f664b182b7e1fb75f1dd09f92d865dababe8525dfe8b
```

I also tested with private images with the following policy, which allows all system pods but requires signatures for the defined registryScopes:

```json
 {
  "version": "1.0",
  "trustPolicies": [
    {
      "name": "aws-signer-ecr-private",
      "registryScopes": [
        "redacted.dkr.ecr.us-west-2.amazonaws.com/alpine-clone",
        "redacted.dkr.ecr.us-west-2.amazonaws.com/nginx-notation-signed"
      ],
      "signatureVerification": {
        "level": "strict",
        "override": {
          "revocation": "skip"
        }
      },
      "trustStores": [
        "signingAuthority:aws-signer-ts"
      ],
      "trustedIdentities": [
        "arn:aws:signer:us-west-2:redacted:/signing-profiles/notation_test"
      ]
    },
    {
      "name": "allow-all-others",
      "registryScopes": [
        "*"
      ],
      "signatureVerification": {
        "level": "skip"
      }
    }
  ]
}
```

When I apply a pod like:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: notation-test
spec:
  replicas: 1
  selector:
    matchLabels:
      app: notation-test
  template:
    metadata:
      labels:
        app: notation-test
    spec:
      containers:
      - name: notation-signed-alpine
        image: redacted.dkr.ecr.us-west-2.amazonaws.com/alpine-clone@sha256:24ba417e25e780ff13c888ccb1badec5b027944666ff695681909bafe09a3944
        command: ["sleep", "infinity"]
      - name: notation-signed-nginx
        image: redacted.dkr.ecr.us-west-2.amazonaws.com/nginx-notation-signed@sha256:17ae566734b63632e543c907ba74757e0c1a25d812ab9f10a07a6bed98dd199c
        command: ["sleep", "infinity"]
      - name: notation-unsigned-should-fail
        image: redacted.dkr.ecr.us-west-2.amazonaws.com/alpine-clone@sha256:216266c86fc4dcef5619930bd394245824c2af52fd21ba7c6fa0e618657d4c3b
        command: ["sleep", "infinity"]
```

I see only the unsigned fail to pull, rejected for image signature verification.

</details>

- [x] digestion verifier on k8s

<details>

Trust policy that allows digest of `public.ecr.aws/docker/library/redis:7.4.8-alpine3.21` only:

```
bash-5.2# apiclient get settings.image
{
  "settings": {
    "image-verifier-plugins": {
      "digestion": {
        "trustpolicy": "ewogICJ2ZXJzaW9uIjogIjEuMCIsCiAgInRydXN0ZWREaWdlc3RzIjogWwogICAgInNoYTI1Njo3YWVjNzM0YjJiYjI5OGExZDc2OWZkODcyOWYxM2I4NTE0YTQxYmY5MGZjZGQxZjM4ZWM1MjI2N2ZiYWE4ZWU2IgogIF0KfQo="
      },
      "enabled": true
    }
  }
}
```

Test for allow/deny:

```
bash-5.2# ctr i pull public.ecr.aws/docker/library/redis:7.4.8-alpine3.21
...
Pulling from OCI Registry (public.ecr.aws/docker/library/redis:7.4.8-alpine3.21)        elapsed: 2.3 s  total:  16.5 M  (7.2 MiB/s)

bash-5.2# ctr i pull public.ecr.aws/docker/library/redis:6.2.20-alpine3.21
ctr: image verifier bindir blocked pull of public.ecr.aws/docker/library/redis:6.2.20-alpine3.21 with digest sha256:77697a75da9f94e9357b61fcaf8345f69e3d9d32e9d15032c8415c21263977dc for reason: verifier digestion-image-verifier rejected image (exit code 1): image verification failed: digest not in allowlist
```

</details>

- [x] custom verifier on k8s

<details>

Used the Dockerfile and Go program below. The Go program checks for existence of a mock config file; if present, pass, if not, fail. The Go binary is written to `/.bottlerocket/rootfs/opt/civ/bin/custom-verifier`, which is the `bin_dir` configured for containerd image verifiers. Configured as a bootstrap container on k8s instance with user-data script below b64 encoded for the "allow" case. For deny case, adjusted the script to not include configuration file.

```Dockerfile
FROM golang:1.21-alpine AS builder

WORKDIR /app
COPY custom-civ/ .

RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o custom-verifier .

FROM public.ecr.aws/bottlerocket/bottlerocket-bootstrap:v0.2.15

RUN mkdir -p /.bottlerocket/rootfs/opt/civ/bin /.bottlerocket/rootfs/var/lib
RUN echo "civ-test-config" > /.bottlerocket/rootfs/var/lib/civ-config

COPY --from=builder /app/custom-verifier /.bottlerocket/rootfs/opt/civ/bin/custom-verifier
RUN chmod +x /.bottlerocket/rootfs/opt/civ/bin/custom-verifier
```

```sh
#!/bin/bash
# Create directories and copy binary to host
mkdir -p /.bottlerocket/rootfs/opt/civ/bin /.bottlerocket/rootfs/var/lib
cp /usr/local/bin/custom-verifier /.bottlerocket/rootfs/opt/civ/bin/custom-verifier
chmod +x /.bottlerocket/rootfs/opt/civ/bin/custom-verifier

# Create mock configuration file
echo "civ-test-config" > /.bottlerocket/rootfs/var/lib/civ-config

echo "Bootstrap setup complete"
```

```go
// The mock verifier

package main

import (
        "os"
)

func main() {
        if _, err := os.Stat("/var/lib/civ-config"); err != nil {
                os.Exit(1)
        }
        os.Exit(0)
}
```

On the instance:

```
bash-5.2# ls /opt/civ/bin
custom-verifier  digestion-image-verifier  notation-image-verifier

bash-5.2# ls /var/lib/civ-config
/var/lib/civ-config

bash-5.2# ctr i pull docker.io/library/hello-world:latest
...
Completed pull from OCI Registry (docker.io/library/hello-world:latest) elapsed: 3.6 s  total:  42.3 K  (11.7 KiB/s)
```

With script that does not write config file to /var/lib/civ-config, pull rejected by `custom-verifier`.

</details>

- [x] digestion verifier on ecs-3

<details>

Same process as digestion verifier test on k8s with only `public.ecr.aws/docker/library/redis:7.4.8-alpine3.21` in digest allowlist:

```
bash-5.2# ctr i pull public.ecr.aws/docker/library/redis:7.4.8-alpine3.21
...
Pulling from OCI Registry (public.ecr.aws/docker/library/redis:7.4.8-alpine3.21)        elapsed: 1.4 s  total:  16.5 M  (11.7 MiB/s)

bash-5.2# ctr i pull public.ecr.aws/docker/library/redis:6.2.20-alpine3.21
ctr: image verifier bindir blocked pull of public.ecr.aws/docker/library/redis:6.2.20-alpine3.21 with digest sha256:77697a75da9f94e9357b61fcaf8345f69e3d9d32e9d15032c8415c21263977dc for reason: verifier digestion-image-verifier rejected image (exit code 1): image verification failed: digest not in allowlist
```

</details>

- [x] custom verifier on ecs-3

<details>
Same userdata for image-verifier-plugins and boostrap-containers as the k8s testing above.
</details>

- [x] Settings migration up/down testing
<details>

On ecs-3 variant. After 1.61.0 upgrade, my image verifier settings remain:

```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "3adeb5d4-dirty",
    "pretty_name": "Bottlerocket OS 1.61.0 (aws-ecs-3)",
    "variant_id": "aws-ecs-3",
    "version_id": "1.61.0"
  }
}
[ssm-user@control]$ apiclient get settings.image
{
  "settings": {
    "image-verifier-plugins": {
      "enabled": true,
      "my-fake-verifier": {
        "trustpolicy": "ewogICJ2ZXJzaW9uIjogIjEuMCIsCiAgInRydXN0ZWREaWdlc3RzIjogWwogICAgInNoYTI1Njo3YWVjNzM0YjJiYjI5OGExZDc2OWZkODcyOWYxM2I4NTE0YTQxYmY5MGZjZGQxZjM4ZWM1MjI2N2ZiYWE4ZWU2IgogIF0KfQo="
      }
    }
  }
}
```

Downgrade:

```
bash-5.2# signpost rollback-to-inactive
bash-5.2# reboot

...

[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "c1f9ba0c",
    "pretty_name": "Bottlerocket OS 1.60.0 (aws-ecs-3)",
    "variant_id": "aws-ecs-3",
    "version_id": "1.60.0"
  }
}
[ssm-user@control]$ apiclient get settings.image
{
  "settings": {
    "image-verifier-plugins": {
      "enabled": true,
      "my-custom": {
        "trustpolicy": "ewogICJ2ZXJzaW9uIjogIjEuMCIsCiAgInRydXN0ZWREaWdlc3RzIjogWwogICAgInNoYTI1Njo3YWVjNzM0YjJiYjI5OGExZDc2OWZkODcyOWYxM2I4NTE0YTQxYmY5MGZjZGQxZjM4ZWM1MjI2N2ZiYWE4ZWU2IgogIF0KfQo="
      }
    }
  }
}
```

Existing settings remain for ecs ✅ 

Now for k8s:

```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "c1f9ba0c",
    "pretty_name": "Bottlerocket OS 1.60.0 (aws-k8s-1.34)",
    "variant_id": "aws-k8s-1.34",
    "version_id": "1.60.0"
  }
}

bash-5.2# apiclient get settings.image
{}

updog update -i 1.61.0 -r -n

[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "3adeb5d4-dirty",
    "pretty_name": "Bottlerocket OS 1.61.0 (aws-k8s-1.34)",
    "variant_id": "aws-k8s-1.34",
    "version_id": "1.61.0"
  }
}
```

Downgrade:

```
bash-5.2# signpost rollback-to-inactive
bash-5.2# reboot

...

[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "c1f9ba0c",
    "pretty_name": "Bottlerocket OS 1.60.0 (aws-k8s-1.34)",
    "variant_id": "aws-k8s-1.34",
    "version_id": "1.60.0"
  }
}
[ssm-user@control]$ apiclient get settings.image
{}
[ssm-user@control]$
```


</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
