### PR TITLE
Update host-containers to 0.21.0 and bootstrap-container to 0.3.0

### DIFF
--- a/sources/shared-defaults/aws-bootstrap-container.toml
+++ b/sources/shared-defaults/aws-bootstrap-container.toml
@@ -1,4 +1,4 @@
 [metadata.settings.bootstrap-containers.source.setting-generator]
-command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-bootstrap:v0.2.16'"
+command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-bootstrap:v0.3.0'"
 strength = "weak"
 depth = 1

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -14,5 +14,5 @@ enabled = true
 superpowered = false
 
 [metadata.settings.host-containers.control.source.setting-generator]
-command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.20.6'"
+command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.21.0'"
 strength = "weak"

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -3,7 +3,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source.setting-generator]
-command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.20.6'"
+command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.21.0'"
 strength = "weak"
 
 [metadata.settings.host-containers.admin.user-data]

--- a/sources/shared-defaults/public-bootstrap-containers.toml
+++ b/sources/shared-defaults/public-bootstrap-containers.toml
@@ -1,4 +1,4 @@
 [metadata.settings.bootstrap-containers.source.setting-generator]
-command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-bootstrap:v0.2.16'"
+command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-bootstrap:v0.3.0'"
 strength = "weak"
 depth = 1

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -8,7 +8,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source.setting-generator]
-command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-admin:v0.20.6'"
+command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-admin:v0.21.0'"
 strength = "weak"
 
 [settings.host-containers.control]

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -16,5 +16,5 @@ enabled = false
 superpowered = false
 
 [metadata.settings.host-containers.control.source.setting-generator]
-command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-control:v0.20.6'"
+command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-control:v0.21.0'"
 strength = "weak"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**


Bootstrap Container: [v0.3.0](https://github.com/bottlerocket-os/bottlerocket-bootstrap-container/releases/tag/v0.3.0)
Admin Container: [v0.21.0](https://github.com/bottlerocket-os/bottlerocket-admin-container/releases/tag/v0.21.0)
Control Container: [v0.21.0](https://github.com/bottlerocket-os/bottlerocket-control-container/releases/tag/v0.21.0)


**Testing done:**

```
bash-5.2# apiclient get settings.host-containers
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.21.0",
        "superpowered": true,
        "user-data": "eyJzc2giOnsiYXV0aG9yaXplZC1rZXlzIjpbXX19"
      },
      "control": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.21.0",
        "superpowered": false
      }
    }
  }
}
```

```
May 14 02:16:45 ip-172-31-49-195.us-west-2.compute.internal bootstrap-containers@test[2300]: 02:16:45 [INFO] Mode for 'test' is 'once'
May 14 02:16:45 ip-172-31-49-195.us-west-2.compute.internal bootstrap-containers@test[2300]: 02:16:45 [INFO] Turning off container 'test'
May 14 02:16:45 ip-172-31-49-195.us-west-2.compute.internal systemd[1]: Finished bootstrap container test.
bash-5.2# 
bash-5.2# 
bash-5.2# 
bash-5.2# apiclient get settings.bootstrap-containers
{
  "settings": {
    "bootstrap-containers": {
      "test": {
        "mode": "off",
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-bootstrap:v0.3.0",
        "user-data": "IyEvYmluL2Jhc2gKZWNobyAnaGVsbG8gd29ybGQnCg=="
      }
    }
  }
}

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
