### PR TITLE
Bump kernel kit to v5.5.1

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "0eWj4taxRMckHeUNLcPSAS8dYNessdJrDR1+poSjqM4="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.5.0"
+version = "5.5.1"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.5.0"
-digest = "P53kyrWy7GdGpasy3WpIAiUNvH0YI/K3IPo4Fnk3Lws="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v5.5.1"
+digest = "WLwJQnTp9Oqn0VbRCfUwdSoky2yaD1RW+L/OYs6B1Wk="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "5.5.0"
+version = "5.5.1"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
**Description of changes:**

Bump kernel kit to v5.5.1

**Testing done:**

Launched 2 instances one of each arch, instances boot.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
