### PR TITLE
docs: fix stale testsys paths in testing guide

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -23,9 +23,8 @@ cargo make \
 
 Unit tests will only get us so far.
 Ultimately we want to know if Bottlerocket runs correctly as a complete system.
-We have created a [command line utility] and [testing system] to help us test Bottlerocket holistically.
+We use the `testsys` CLI through `cargo make testsys`, alongside the [testing system], to test Bottlerocket holistically.
 
-[command line utility]: ./tools/testsys
 [testing system]: https://github.com/bottlerocket-os/bottlerocket-test-system
 
 The test system coordinates:
@@ -127,7 +126,8 @@ Now that you have the testsys cluster set up, it's time to run a Bottlerocket in
 ### Configuration
 
 There are many arguments that can be configured via environment variables with `cargo make`; however, it is possible to create a configuration file instead.
-Check out the [example config file](tools/testsys/Test.toml.example) for a sample `Test.toml` file.
+By default, `cargo make` looks for `Test.toml` in the repository root, and falls back to `tests/Test.toml` if the root file is absent.
+If both files exist, `cargo make` exits with an error so there is only one active test configuration.
 
 For example, the instance type can be specified based on variant requirements:
 


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Tiny doc drift fix. `TESTING.md` pointed to `./tools/testsys` and `tools/testsys/Test.toml.example`, but both paths are gone in a fresh checkout.

This updates the guide to match what the repo does today: use `cargo make testsys`, and put test config in `Test.toml` at the repo root or `tests/Test.toml`. Keeps folks from chasing ghosts, pretty much it.

Repro:
```shell
test -e tools/testsys && echo exists || echo missing
test -e tools/testsys/Test.toml.example && echo exists || echo missing
```

**Testing done:**
Checked the dead paths above in a fresh checkout.
Checked the replacement text against `Makefile.toml` config lookup logic.
Ran a local markdown link check for `TESTING.md` and there are no missing local links now.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
