### PR TITLE
chore: bump twoliter to 0.20.0

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,9 +8,9 @@ BUILDSYS_ROOT_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}"
 # For binary installation, this should be a released version (prefixed with a v,
 # for example v0.1.0). For the git sourcecode installation method, this can be
 # any git rev, e.g. a tag, sha, or branch name.
-TWOLITER_VERSION = "v0.19.0"
-TWOLITER_SHA256_AARCH64 = "10700d50b545d0e3bf8a7ca1444a7825fd9c1645b41c829dc5864c92a3ca0032"
-TWOLITER_SHA256_X86_64 = "11f92b594868bccd241002dfd40ca99fce7360a7a9c26163ad43552e4671290e"
+TWOLITER_VERSION = "v0.20.0"
+TWOLITER_SHA256_AARCH64 = "25e97fc63003e1c67b262d8ea3d7ca0ae934223805289edb130d80e1f0ef54a8"
+TWOLITER_SHA256_X86_64 = "6a102249ba567f681ce25ed02fb588a51397d66a27cde4dce2e56b92d45c2dff"
 
 # For binary installation, this is the GitHub repository that has binary release artifacts attached
 # to it, for example https://github.com/bottlerocket-os/twoliter. For git sourcecode installation,


### PR DESCRIPTION


**Description of changes:**


Bump to latest twoliter release


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
