### PR TITLE
Update admin, control, and bootstrap containers

### DIFF
--- a/sources/shared-defaults/aws-bootstrap-container.toml
+++ b/sources/shared-defaults/aws-bootstrap-container.toml
@@ -1,4 +1,4 @@
 [metadata.settings.bootstrap-containers.source.setting-generator]
-command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-bootstrap:v0.3.0'"
+command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-bootstrap:v0.3.2'"
 strength = "weak"
 depth = 1

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -14,5 +14,5 @@ enabled = true
 superpowered = false
 
 [metadata.settings.host-containers.control.source.setting-generator]
-command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.21.0'"
+command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-control:v0.21.2'"
 strength = "weak"

--- a/sources/shared-defaults/aws-host-containers.toml
+++ b/sources/shared-defaults/aws-host-containers.toml
@@ -3,7 +3,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source.setting-generator]
-command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.21.0'"
+command = "schnauzer-v2 render --requires 'aws@v1(helpers=[ecr-prefix])' --template '{{ ecr-prefix settings.aws.region }}/bottlerocket-admin:v0.21.2'"
 strength = "weak"
 
 [metadata.settings.host-containers.admin.user-data]

--- a/sources/shared-defaults/public-bootstrap-containers.toml
+++ b/sources/shared-defaults/public-bootstrap-containers.toml
@@ -1,4 +1,4 @@
 [metadata.settings.bootstrap-containers.source.setting-generator]
-command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-bootstrap:v0.3.0'"
+command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-bootstrap:v0.3.2'"
 strength = "weak"
 depth = 1

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -16,5 +16,5 @@ enabled = false
 superpowered = false
 
 [metadata.settings.host-containers.control.source.setting-generator]
-command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-control:v0.21.0'"
+command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-control:v0.21.2'"
 strength = "weak"

--- a/sources/shared-defaults/public-host-containers.toml
+++ b/sources/shared-defaults/public-host-containers.toml
@@ -8,7 +8,7 @@ enabled = false
 superpowered = true
 
 [metadata.settings.host-containers.admin.source.setting-generator]
-command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-admin:v0.21.0'"
+command = "schnauzer-v2 render --template 'public.ecr.aws/bottlerocket/bottlerocket-admin:v0.21.2'"
 strength = "weak"
 
 [settings.host-containers.control]


### PR DESCRIPTION
**Description of changes:**

This updates the containers that were just released ⤵︎

Bootstrap Container: [v0.3.2](https://github.com/bottlerocket-os/bottlerocket-bootstrap-container/releases/tag/v0.3.2)
Admin Container: [v0.21.2](https://github.com/bottlerocket-os/bottlerocket-admin-container/releases/tag/v0.21.2)
Control Container: [v0.21.2](https://github.com/bottlerocket-os/bottlerocket-control-container/releases/tag/v0.21.2)

**Testing done:**
```bash
apiclient get settings.bootstrap-containers
```

```json
{
  "settings": {
    "bootstrap-containers": {
      "bear": {
        "mode": "off",
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-bootstrap:v0.3.2",
        "user-data": "IyEvdXNyL2Jpbi9lbnYgc2gKc2V0IC1ldW8gcGlwZWZhaWwKCiMgQ3JlYXRlIHRoZSBkaXJlY3RvcnkKbWtkaXIgLXAgL3Zhci9saWIvbXlfZGlyZWN0b3J5CgojIFNldCBBUEkgY2xpZW50IGNvbmZpZ3VyYXRpb25zCmFwaWNsaWVudCBzZXQgLS1qc29uICd7InNldHRpbmdzIjogeyJvY2ktZGVmYXVsdHMiOiB7InJlc291cmNlLWxpbWl0cyI6IHsibWF4LW9wZW4tZmlsZXMiOiB7InNvZnQtbGltaXQiOiA0Mjk0OTY3Mjk2LCAiaGFyZC1saW1pdCI6IDg1ODk5MzQ1OTJ9fX19fScKCiMgTG9hZCBrZXJuZWwgbW9kdWxlCmlmIGNvbW1hbmQgLXYgbW9kcHJvYmUgPiAvZGV2L251bGwgMj4mMTsgdGhlbgogIG1vZHByb2JlIGR1bW15CmZpCgplY2hvICJVc2VyLWRhdGEgc2NyaXB0IGV4ZWN1dGVkLiIK"
      }
    }
  }
}
```

```bash
apiclient get settings.host-containers
```

```json
{
  "settings": {
    "host-containers": {
      "admin": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:v0.21.2",
        "superpowered": true,
        "user-data": "XXXXXXXXXXXXXX"
      },
      "control": {
        "enabled": true,
        "source": "328549459982.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-control:v0.21.2",
        "superpowered": false
      }
    }
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
