### PR TITLE
Add support for static and transparent hugepages

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -477,4 +477,5 @@ version = "1.64.0"
 ]
 "(1.63.0, 1.64.0)" = [
     "migrate_v1.64.0_kubernetes-container-runtime-endpoint.lz4",
+    "migrate_v1.64.0_hugepages-settings.lz4"
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -960,6 +960,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "hugepages-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -66,6 +66,7 @@ members = [
     "settings-migrations/v1.63.0/image-verifier-plugins-settings",
     "settings-migrations/v1.63.0/nvidia-k8s-device-plugin-enabled",
     "settings-migrations/v1.64.0/kubernetes-container-runtime-endpoint",
+    "settings-migrations/v1.64.0/hugepages-settings",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/settings-migrations/v1.64.0/hugepages-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.64.0/hugepages-settings/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "hugepages-settings"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.64.0/hugepages-settings/src/main.rs
+++ b/sources/settings-migrations/v1.64.0/hugepages-settings/src/main.rs
@@ -1,0 +1,22 @@
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added new settings for hugepages related settings:
+/// - settings.kernel.hugepages.*
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.kernel.hugepages",
+        "services.hugepages",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}

--- a/sources/shared-defaults/defaults.toml
+++ b/sources/shared-defaults/defaults.toml
@@ -137,6 +137,13 @@ restart-commands = ["/usr/bin/corndog lockdown"]
 [metadata.settings.kernel.lockdown]
 affected-services = ["lockdown"]
 
+[services.hugepages]
+configuration-files = ["corndog-toml"]
+restart-commands = []
+
+[metadata.settings.kernel.hugepages]
+affected-services = ["hugepages"]
+
 [configuration-files.corndog-toml]
 path = "/etc/corndog.toml"
 template-path = "/usr/share/templates/corndog-toml"


### PR DESCRIPTION
Closes #

**Description of changes:**
- Add support for hugepages

**Testing done:**
Set the following settings:
```
[ssm-user@control]$ apiclient apply  <<EOF
[settings.kernel.hugepages."2Mi"]
> count = 200
> [settings.kernel.hugepages."1Gi"]
> count = 2
> EOF
[ssm-user@control]$ apiclient get settings.kernel.hugepages
{
  "settings": {
    "kernel": {
      "hugepages": {
        "1Gi": {
          "count": 2
        },
        "2Mi": {
          "count": 200
        }
      }
    }
  }
}
[ssm-user@control]$ cat /proc/meminfo | grep ^Huge
HugePages_Total:       0
HugePages_Free:        0
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:               0 kB
```
The hugepages are not allocated yet because we have set it up to allocate only at boot.

Post reboot:
1. Meminfo output:
```
bash-5.2# cat /proc/meminfo | grep ^Huge
HugePages_Total:     200
HugePages_Free:      200
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:         2506752 kB
```
200 hugepages of default size has been allocated. Hugetlb size = 2048*200 + 1048576*2 = 2506752 kB

2. Describe node output
`$ kubectl describe node --kubeconfig bottlerocket-cluster-134.kubeconfig`
[Output trimmed for brevity]
```
Capacity:
  cpu:                128
  ephemeral-storage:  20100288Ki
  hugepages-1Gi:      2Gi
  hugepages-2Mi:      400Mi
  memory:             259892560Ki
  pods:               737
Allocatable:
  cpu:                127610m
  ephemeral-storage:  17450683567
  hugepages-1Gi:      2Gi
  hugepages-2Mi:      400Mi
  memory:             248720720Ki
  pods:               737
```
As we can see the hugepages show up as allocatable resources.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
