### PR TITLE
twoliter: bump kernel-kit to v6.2.2

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "9cSjjYDqIrlIjnOjLYbHGG5khRYA+wCek8I0BqP3sII="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "6.2.0"
+version = "6.2.2"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v6.2.0"
-digest = "XflEic+k1EnVos73r+TCzFGY82iadrXtBcgbAkJqmGY="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v6.2.2"
+digest = "Euek+5PjWtgY/Y5jJ6od3nx65RnDsMBP2JlgYlWJ0FU="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "6.2.0"
+version = "6.2.2"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**

Bump `bottlerocket-kernel-kit` from `v6.2.0` to `v6.2.2`. v6.2.2 normalizes NVIDIA r595 library paths under `/usr/lib/`

**Testing done:**

Built `aws-k8s-1.36-nvidia` and launched on `g7.2xlarge`. `nvidia-smi` reports driver 595.71.05; `nvidia-k8s-device-plugin.service` is `active (running)`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
