### PR TITLE
Bump containerd-2.1 variants to containerd-2.2

### DIFF
--- a/variants/aws-dev/Cargo.toml
+++ b/variants/aws-dev/Cargo.toml
@@ -31,7 +31,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.18",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3-fips/Cargo.toml
+++ b/variants/aws-ecs-3-fips/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3-nvidia-fips/Cargo.toml
+++ b/variants/aws-ecs-3-nvidia-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3-nvidia/Cargo.toml
+++ b/variants/aws-ecs-3-nvidia/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-3/Cargo.toml
+++ b/variants/aws-ecs-3/Cargo.toml
@@ -21,7 +21,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-4-nvidia/Cargo.toml
+++ b/variants/aws-ecs-4-nvidia/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.18",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-ecs-4/Cargo.toml
+++ b/variants/aws-ecs-4/Cargo.toml
@@ -21,7 +21,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.18",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.31-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.31-nvidia-fips/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.32-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.32-nvidia-fips/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.33-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.1",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
 # k8s
     "cni",

--- a/variants/aws-k8s-1.33-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia-fips/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.33-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.33-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
     # k8s
     "cni",

--- a/variants/aws-k8s-1.33/Cargo.toml
+++ b/variants/aws-k8s-1.33/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
 # k8s
     "cni",

--- a/variants/aws-k8s-1.34-fips/Cargo.toml
+++ b/variants/aws-k8s-1.34-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.34-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.34-nvidia-fips/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.34-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.34-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.34/Cargo.toml
+++ b/variants/aws-k8s-1.34/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35-fips/Cargo.toml
+++ b/variants/aws-k8s-1.35-fips/Cargo.toml
@@ -23,7 +23,7 @@ included-packages = [
 # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.35-nvidia-fips/Cargo.toml
@@ -26,7 +26,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.35-nvidia/Cargo.toml
@@ -25,7 +25,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/aws-k8s-1.35/Cargo.toml
+++ b/variants/aws-k8s-1.35/Cargo.toml
@@ -22,7 +22,7 @@ included-packages = [
 # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-dev/Cargo.toml
+++ b/variants/vmware-dev/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
 # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.33-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.33-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.1",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
     # k8s
     "cni",

--- a/variants/vmware-k8s-1.33/Cargo.toml
+++ b/variants/vmware-k8s-1.33/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "whippet",
     # k8s
     "cni",

--- a/variants/vmware-k8s-1.34-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.34-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.34/Cargo.toml
+++ b/variants/vmware-k8s-1.34/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.35-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.35-fips/Cargo.toml
@@ -36,7 +36,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",

--- a/variants/vmware-k8s-1.35/Cargo.toml
+++ b/variants/vmware-k8s-1.35/Cargo.toml
@@ -35,7 +35,7 @@ included-packages = [
     # core
     "release-swap",
     "kernel-6.12",
-    "containerd-2.1",
+    "containerd-2.2",
     "systemd-257",
     "nftables",
     "whippet",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
Bump containerd-2.1 variants to containerd 2.2

**Related PR**
This is the prerequisite for bottlerocket-os/bottlerocket-core-kit#967, which drops the containerd-2.1 package from the core kit.

**Testing done**
- Verified containerd-2.1 does not present in Bottlerocket repo
- Built Amis against core-kit that dropped containerd-2.1
- Comformance test on all normal/nvidia/fips amis

| Variant | x86_64 | aarch64 | Conformance | Extra workload |
|---|:---:|:---:|---|---|
| aws-k8s-1.33 | ✅ | ✅ | passed / 0 failed | runtime-smoke |
| aws-k8s-1.34 | ✅ | ✅ | passed / 0 failed | runtime-smoke |
| aws-k8s-1.35 | ✅ | ✅ | passed / 0 failed | runtime-smoke |
| aws-k8s-1.33-nvidia | ✅ | ✅ | passed / 0 failed | runtime-smoke + nvidia-smoke |
| aws-k8s-1.34-nvidia | ✅ | ✅ | passed / 0 failed | runtime-smoke + nvidia-smoke |
| aws-k8s-1.35-nvidia | ✅ | ✅ | passed / 0 failed | runtime-smoke + nvidia-smoke |
| aws-k8s-1.33-fips | ✅ | ✅ | 395 passed / 0 failed | runtime-smoke + TestFIPSTLS |
| aws-k8s-1.34-fips | ✅ | ✅ | 402 passed / 0 failed | runtime-smoke + TestFIPSTLS |
| aws-k8s-1.35-fips | ✅ | ✅ | 402/422 passed / 0 failed | runtime-smoke + TestFIPSTLS |

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
