### PR TITLE
twoliter: bump core-kit version to v14.7.0

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -17,7 +17,7 @@ digest = "XflEic+k1EnVos73r+TCzFGY82iadrXtBcgbAkJqmGY="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "14.6.0"
+version = "14.7.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v14.6.0"
-digest = "XGT5HjzTRiAFewZfSD0Md0aUXIXxNQmwahW/8diILgU="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v14.7.0"
+digest = "+hIjfb7IsLTaDFrRPCdSYXVedLk3kForvsnkQXAxo2g="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -17,5 +17,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "14.6.0"
+version = "14.7.0"
 vendor = "bottlerocket"


### PR DESCRIPTION
**Description of changes:**
bumps core-kit version to v14.7.0

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
