### PR TITLE
Add gdrcopy driver to aws-ecs-4-nvidia variant

### DIFF
--- a/variants/aws-ecs-4-nvidia/Cargo.toml
+++ b/variants/aws-ecs-4-nvidia/Cargo.toml
@@ -40,6 +40,7 @@ included-packages = [
     "ecs-gpu-init",
     "nvidia-container-toolkit-ecs",
     "kmod-6.18-nvidia-r580-tesla",
+    "kmod-6.18-nvidia-r580-gdrcopy",
     "kmod-6.18-nvidia-r580-imex-config",
 ]
 


### PR DESCRIPTION
**Description of changes:**

Add `gdrcopy` driver to `aws-ecs-4-nvidia`

**Testing done:**

In https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/462, I detailed the testing.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
