### PR TITLE
twoliter: bump kernel-kit to v6.3.0

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "9cSjjYDqIrlIjnOjLYbHGG5khRYA+wCek8I0BqP3sII="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "6.2.0"
+version = "6.3.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v6.2.0"
-digest = "XflEic+k1EnVos73r+TCzFGY82iadrXtBcgbAkJqmGY="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v6.3.0"
+digest = "W17xKVV2ETNQU+qUGoRm4rS0W2TxFWzi4YU/Yl7fYEY="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "6.2.0"
+version = "6.3.0"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
**Description of changes:**
- kernel-kit bump to v6.3.0


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
