### PR TITLE
Add migration for new setting `settings.measurement.excluded-settings`

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.63.0"
+version = "1.64.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -474,4 +474,7 @@ version = "1.63.0"
 "(1.62.1, 1.63.0)" = [
     "migrate_v1.63.0_image-verifier-plugins-settings.lz4",
     "migrate_v1.63.0_nvidia-k8s-device-plugin-enabled.lz4",
+]
+"(1.63.0, 1.64.0)" = [
+    "migrate_v1.64.0_measurement-excluded-settings.lz4",
 ]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "1.63.0"
+release-version = "1.64.0"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1295,6 +1295,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "measurement-excluded-settings"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -65,6 +65,7 @@ members = [
     "settings-migrations/v1.60.0/container-runtime-max-concurrent-unpacks",
     "settings-migrations/v1.63.0/image-verifier-plugins-settings",
     "settings-migrations/v1.63.0/nvidia-k8s-device-plugin-enabled",
+    "settings-migrations/v1.64.0/measurement-excluded-settings",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/settings-migrations/v1.64.0/measurement-excluded-settings/Cargo.toml
+++ b/sources/settings-migrations/v1.64.0/measurement-excluded-settings/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "measurement-excluded-settings"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.64.0/measurement-excluded-settings/src/main.rs
+++ b/sources/settings-migrations/v1.64.0/measurement-excluded-settings/src/main.rs
@@ -1,0 +1,21 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring which settings are excluded from PCR 8 measurement:
+/// - settings.measurement.excluded-settings
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.measurement.excluded-settings",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}

--- a/sources/settings-plugins/aws-dev/src/lib.rs
+++ b/sources/settings-plugins/aws-dev/src/lib.rs
@@ -19,4 +19,5 @@ struct AwsDevSettings {
     oci_hooks: bottlerocket_settings_models::OciHooksSettingsV1,
     cloudformation: bottlerocket_settings_models::CloudFormationSettingsV1,
     dns: bottlerocket_settings_models::DnsSettingsV1,
+    measurement: bottlerocket_settings_models::MeasurementSettingsV1,
 }

--- a/sources/settings-plugins/aws-ecs-3/src/lib.rs
+++ b/sources/settings-plugins/aws-ecs-3/src/lib.rs
@@ -24,4 +24,5 @@ struct AwsEcs3Settings {
     autoscaling: bottlerocket_settings_models::AutoScalingSettingsV1,
     dns: bottlerocket_settings_models::DnsSettingsV1,
     image_verifier_plugins: bottlerocket_settings_models::ImageVerifierPluginsSettingsV1,
+    measurement: bottlerocket_settings_models::MeasurementSettingsV1,
 }

--- a/sources/settings-plugins/aws-ecs-4/src/lib.rs
+++ b/sources/settings-plugins/aws-ecs-4/src/lib.rs
@@ -24,4 +24,5 @@ struct AwsEcs4Settings {
     autoscaling: bottlerocket_settings_models::AutoScalingSettingsV1,
     dns: bottlerocket_settings_models::DnsSettingsV1,
     image_verifier_plugins: bottlerocket_settings_models::ImageVerifierPluginsSettingsV1,
+    measurement: bottlerocket_settings_models::MeasurementSettingsV1,
 }

--- a/sources/settings-plugins/vmware-dev/src/lib.rs
+++ b/sources/settings-plugins/vmware-dev/src/lib.rs
@@ -17,4 +17,5 @@ struct VmwareDevSettings {
     container_registry: bottlerocket_settings_models::RegistrySettingsV1,
     oci_hooks: bottlerocket_settings_models::OciHooksSettingsV1,
     dns: bottlerocket_settings_models::DnsSettingsV1,
+    measurement: bottlerocket_settings_models::MeasurementSettingsV1,
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Is half of https://github.com/bottlerocket-os/bottlerocket/issues/4872 (the non-pcrsys changes)

**Description of changes:**

Add migration for `settings.measurement.excluded-settings`

**Testing done:**

### Forward Migration



`updog check-update -a --json` output confirmed v1.64.0 was discoverable:
- Variant: `aws-ecs-3`
- Architecture: `x86_64`
- Version: `1.64.0`
- Migration list included `migrate_v1.64.0_measurement-excluded-settings`


`updog update -i 1.64.0 -r -n` output:

```
Starting update to 1.64.0
Reboot scheduled for Mon 2026-07-20 19:07:03 UTC
Update applied: aws-ecs-3 1.64.0
```

Instance rebooted and came back online at v1.64.0

```
$ apiclient get settings.measurement
{}
```

- `apiclient get settings.measurement` returned `{}` with exit code 0

```json
{
  "os": {
    "arch": "x86_64",
    "build_id": "9e392d7b",
    "pretty_name": "Bottlerocket OS 1.64.0 (aws-ecs-3)",
    "variant_id": "aws-ecs-3",
    "version_id": "1.64.0"
  }
}
```

### Backward Migration


1. `signpost rollback-to-inactive`
2. `reboot`
3. Instance returned to v1.63.0

```
$ apiclient get settings.measurement
{}
```

- `apiclient get settings` top-level keys: `autoscaling, aws, boot, cloudformation, ecs, host-containers, kernel, metrics, motd, network, ntp, oci-defaults, oci-hooks, updates`, no `measurement`


```json
{
  "os": {
    "arch": "x86_64",
    "build_id": "d4932ff8",
    "pretty_name": "Bottlerocket OS 1.63.0 (aws-ecs-3)",
    "variant_id": "aws-ecs-3",
    "version_id": "1.63.0"
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
