### PR TITLE
Update 1.63.0 kernel kit version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## OS Changes
 * Update `bottlerocket-core-kit` from 14.5.1 to 14.8.0 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/develop/CHANGELOG.md#v1470-2026-07-09) ([commits](https://github.com/bottlerocket-os/bottlerocket-core-kit/compare/v14.5.1...v14.8.0)) ([#4865], [#4873], [#4883])
-* Update `bottlerocket-kernel-kit` from 6.0.0 to 7.0.0 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/blob/develop/CHANGELOG.md#v631-2026-07-10) ([commits](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/compare/v6.0.0...v7.0.0)) ([#4865], [#4875], [#4876], [#4883])
+* Update `bottlerocket-kernel-kit` from 6.0.0 to 7.0.1 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/blob/develop/CHANGELOG.md#v701-2026-07-14) ([commits](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/compare/v6.0.0...v7.0.1)) ([#4865], [#4875], [#4876], [#4883], [#4886])
 * Update `admin-container` from 0.21.2 to 0.21.3 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-admin-container/blob/develop/CHANGELOG.md#0213) ([commits](https://github.com/bottlerocket-os/bottlerocket-admin-container/compare/v0.21.2...v0.21.3)) ([#4876])
 * Update `control-container` from 0.21.2 to 0.21.3 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-control-container/blob/develop/CHANGELOG.md#0213) ([commits](https://github.com/bottlerocket-os/bottlerocket-control-container/compare/v0.21.2...v0.21.3)) ([#4876])
 * Update `bootstrap-container` from 0.3.2 to 0.3.3 [CHANGELOG](https://github.com/bottlerocket-os/bottlerocket-bootstrap-container/blob/develop/CHANGELOG.md#033) ([commits](https://github.com/bottlerocket-os/bottlerocket-bootstrap-container/compare/v0.3.2...v0.3.3)) ([#4876])
@@ -30,6 +30,7 @@
 [#4875]: https://github.com/bottlerocket-os/bottlerocket/pull/4875
 [#4876]: https://github.com/bottlerocket-os/bottlerocket/pull/4876
 [#4883]: https://github.com/bottlerocket-os/bottlerocket/pull/4883
+[#4886]: https://github.com/bottlerocket-os/bottlerocket/pull/4886
 [bottlerocket-core-kit#914]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/914
 [bottlerocket-core-kit#919]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/919
 [bottlerocket-kernel-kit#425]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/425

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "9cSjjYDqIrlIjnOjLYbHGG5khRYA+wCek8I0BqP3sII="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "7.0.0"
+version = "7.0.1"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v7.0.0"
-digest = "9NH0oEzsAGDbKQek/rjzWJZo7xCVnRqmfJHg9lyArcI="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v7.0.1"
+digest = "VYz4zUQ1rQ3EFx/uJPJs7EHG72AOhgQEDH7Fo2SO06g="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "7.0.0"
+version = "7.0.1"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Bump kernel-kit to v7.0.1 and update the changelog for Bottlerocket v1.63.0 to reflect the new kernel-kit version.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
