### PR TITLE
chore: bump bottlerocket-settings-models to 0.25.0

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-defaults-helper"
 version = "0.1.1"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "snafu",
  "toml",
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "darling",
  "quote",
@@ -322,8 +322,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.16.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+version = "0.17.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "serde",
  "serde_plain",
@@ -368,7 +368,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -382,7 +382,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -392,8 +392,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.24.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+version = "0.25.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -418,6 +418,7 @@ dependencies = [
  "settings-extension-kernel",
  "settings-extension-kubelet-device-plugins",
  "settings-extension-kubernetes",
+ "settings-extension-measurement",
  "settings-extension-metrics",
  "settings-extension-motd",
  "settings-extension-network",
@@ -433,7 +434,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-plugin"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "abi_stable",
  "bottlerocket-settings-derive",
@@ -445,7 +446,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -458,7 +459,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "serde",
 ]
@@ -466,7 +467,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2087,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2100,7 +2101,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2113,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2127,7 +2128,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2140,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2153,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2166,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2179,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2195,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2208,7 +2209,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2221,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2234,7 +2235,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-image-verifier-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2247,7 +2248,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2260,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2273,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.10.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2285,9 +2286,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-measurement"
+version = "0.1.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+dependencies = [
+ "bottlerocket-model-derive",
+ "bottlerocket-modeled-types",
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "serde",
+ "serde_json",
+ "snafu",
+]
+
+[[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2300,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -2313,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2326,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2339,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2352,7 +2367,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2366,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2379,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -2392,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -133,27 +133,27 @@ walkdir = "2"
 
 [workspace.dependencies.bottlerocket-defaults-helper]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.23.0"
+tag = "bottlerocket-settings-models-v0.25.0"
 version = "0.1.1"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.24.0"
-version = "0.16.0"
+tag = "bottlerocket-settings-models-v0.25.0"
+version = "0.17.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.24.0"
-version = "0.24.0"
+tag = "bottlerocket-settings-models-v0.25.0"
+version = "0.25.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.24.0"
+tag = "bottlerocket-settings-models-v0.25.0"
 version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.24.0"
+tag = "bottlerocket-settings-models-v0.25.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
**Description of changes:**
- bump bottlerocket-settings-sdk version to v0.25.0

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
