### PR TITLE
migration: add kubernetes container-runtime-endpoint setting

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,4 +1,4 @@
-version = "1.63.0"
+version = "1.64.0"
 
 [migrations]
 "(0.3.1, 0.3.2)" = ["migrate_v0.3.2_admin-container-v0-5-0.lz4"]
@@ -474,4 +474,7 @@ version = "1.63.0"
 "(1.62.1, 1.63.0)" = [
     "migrate_v1.63.0_image-verifier-plugins-settings.lz4",
     "migrate_v1.63.0_nvidia-k8s-device-plugin-enabled.lz4",
+]
+"(1.63.0, 1.64.0)" = [
+    "migrate_v1.64.0_kubernetes-container-runtime-endpoint.lz4",
 ]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "1.63.0"
+release-version = "1.64.0"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1195,6 +1195,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubernetes-container-runtime-endpoint"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "kubernetes-ecr-credential-provider-patterns"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -65,6 +65,7 @@ members = [
     "settings-migrations/v1.60.0/container-runtime-max-concurrent-unpacks",
     "settings-migrations/v1.63.0/image-verifier-plugins-settings",
     "settings-migrations/v1.63.0/nvidia-k8s-device-plugin-enabled",
+    "settings-migrations/v1.64.0/kubernetes-container-runtime-endpoint",
 
     "settings-plugins/aws-dev",
     "settings-plugins/aws-ecs-2",

--- a/sources/settings-migrations/v1.64.0/kubernetes-container-runtime-endpoint/Cargo.toml
+++ b/sources/settings-migrations/v1.64.0/kubernetes-container-runtime-endpoint/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kubernetes-container-runtime-endpoint"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers.workspace = true

--- a/sources/settings-migrations/v1.64.0/kubernetes-container-runtime-endpoint/src/main.rs
+++ b/sources/settings-migrations/v1.64.0/kubernetes-container-runtime-endpoint/src/main.rs
@@ -1,0 +1,21 @@
+use migration_helpers::common_migrations::AddSettingsMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting for configuring the kubelet container runtime endpoint:
+/// - settings.kubernetes.container-runtime-endpoint
+fn run() -> Result<()> {
+    migrate(AddSettingsMigration(&[
+        "settings.kubernetes.container-runtime-endpoint",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related: https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/969

**Description of changes:**

Add setting migration for `settings.kubernetes.container-runtime-endpoint`

**Testing done:**

Built k8s AMI with https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/968.

Both forward (upgrade) and backward (downgrade) migration paths verified successfully.

**Verify starting version**

```
$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "ba769f64",
    "pretty_name": "Bottlerocket OS 1.63.0 (aws-k8s-1.31)",
    "variant_id": "aws-k8s-1.31",
    "version_id": "1.63.0"
  }
}
```

**Check for updates**

```
$ apiclient update check
...
  "available_updates": [
    "1.64.0"
  ],
...
```

Applied update and rebooted.

**Verify upgrade**

```
$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "bbfd8ee9",
    "pretty_name": "Bottlerocket OS 1.64.0 (aws-k8s-1.31)",
    "variant_id": "aws-k8s-1.31",
    "version_id": "1.64.0"
  }
}
```

```
$ apiclient get settings.kubernetes.container-runtime-endpoint
{}

$ apiclient set settings.kubernetes.container-runtime-endpoint=unix:///run/containerd/containerd.sock

$ apiclient get settings.kubernetes.container-runtime-endpoint
{
  "settings": {
    "kubernetes": {
      "container-runtime-endpoint": "unix:///run/containerd/containerd.sock"
    }
  }
}
```


**Rollback (downgrade to 1.63.0)**

```
$ apiclient exec admin sheltie signpost status
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p8 root=/dev/nvme0n1p9 hash=/dev/nvme0n1p10 priority=1 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p3 root=/dev/nvme0n1p4 hash=/dev/nvme0n1p5 priority=2 tries_left=0 successful=true
Active:  Set B
Next:    Set B

$ apiclient exec admin sheltie signpost rollback-to-inactive

$ apiclient reboot
```

**Verify downgrade**

```
$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "ba769f64",
    "pretty_name": "Bottlerocket OS 1.63.0 (aws-k8s-1.31)",
    "variant_id": "aws-k8s-1.31",
    "version_id": "1.63.0"
  }
}
```

```
$ apiclient get settings.kubernetes.container-runtime-endpoint
{}
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
