### PR TITLE
Twoliter: update core-kit and kernel-kit

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "9cSjjYDqIrlIjnOjLYbHGG5khRYA+wCek8I0BqP3sII="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "7.0.1"
+version = "7.1.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v7.0.1"
-digest = "VYz4zUQ1rQ3EFx/uJPJs7EHG72AOhgQEDH7Fo2SO06g="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v7.1.0"
+digest = "aCekwwtcRBWW766NZzL4qrM6JO1h6lAfNzeImpvG3DI="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -17,7 +17,7 @@ digest = "aCekwwtcRBWW766NZzL4qrM6JO1h6lAfNzeImpvG3DI="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "14.8.0"
+version = "14.9.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v14.8.0"
-digest = "LxC+4I5HtrmqyPXTt7mAUdPNZKpLyQvILNC1Lo4x5T0="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v14.9.0"
+digest = "nAN8Du6YDsEEJFZ/RamKv9r/WAnpFkN6UmKuBlseS+M="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -17,5 +17,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "14.8.0"
+version = "14.9.0"
 vendor = "bottlerocket"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "7.0.1"
+version = "7.1.0"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
**Description of changes:**
* bumps core-kit version to v14.9.0
* bumps kernel-kit version to v7.1.0

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
