### PR TITLE
ci: add changelog enforcement workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,21 @@
+name: changelog
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  changelog:
+    # Escape hatch: add the "skip-changelog" label to the PR. Re-runs on label change,
+    # so no re-push needed.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: CHANGELOG.md must be updated
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git diff --name-only "origin/${BASE_REF}...HEAD" \
+            | grep -qx 'CHANGELOG.md' \
+            || { echo '::error file=CHANGELOG.md::PR does not touch CHANGELOG.md. Add an entry, or apply the "skip-changelog" label if this change needs none.'; exit 1; }


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
n/a

**Description of changes:**

Add a GitHub Actions workflow that checks PRs for CHANGELOG.md updates. The check can be skipped by applying the "skip-changelog" label to the PR, which re-triggers the workflow without requiring a re-push.

The intention here is to enforce PR owners to add changelog entries for their changes.


**Testing done:**

https://github.com/ginglis13/bottlerocket/pull/1

https://github.com/ginglis13/bottlerocket/actions/runs/30400762479/job/90414722270?pr=1

```
Error: PR does not touch CHANGELOG.md. Add an entry, or apply the "skip-changelog" label if this change needs none.
Error: Process completed with exit code 1.
```

Added label `skip-changelog`, check skipped.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
