### PR TITLE
ci: add commitlint workflow for PR commit messages

### DIFF
--- a/.commitlint.config.mjs
+++ b/.commitlint.config.mjs
@@ -1,0 +1,48 @@
+/* [commitlint](https://github.com/conventional-changelog/commitlint) configuration
+ *
+ * Bottlerocket repos use a `scope: description` convention where the scope
+ * is typically a package/component name (e.g. `twoliter: bump core-kit to v14.9.0`)
+ * or an area (e.g. `changelog: update changelog for v1.64.0`).
+ *
+ * This differs from standard Conventional Commits which require a fixed type
+ * prefix (feat, fix, etc.). We enforce the structural rules (colon separator,
+ * line lengths, casing) while allowing any lowercase scope before the colon.
+ */
+import { RuleConfigSeverity } from "@commitlint/types";
+
+// Custom plugin to validate the "scope: description" format used in Bottlerocket.
+const kitScopePlugin = {
+  rules: {
+    // Validates that the header matches `lowercase-scope: description`
+    "kit-scope-format": (parsed, _when, _value) => {
+      const header = parsed.header;
+      // Match: one or more lowercase words/numbers/dots/dashes, colon, space, then description
+      const pattern = /^[a-z][a-z0-9._-]*: .+$/;
+      return [
+        pattern.test(header),
+        "header must match the format 'scope: description' (e.g. 'twoliter: bump core-kit to v14.9.0')",
+      ];
+    },
+  },
+};
+
+export default {
+  plugins: [kitScopePlugin],
+  rules: {
+    // Structural rules
+    "header-max-length": [RuleConfigSeverity.Error, "always", 72],
+    "header-trim": [RuleConfigSeverity.Error, "always"],
+    "body-max-line-length": [RuleConfigSeverity.Error, "always", 72],
+    "body-leading-blank": [RuleConfigSeverity.Error, "always"],
+
+    // Subject rules (applied to text after the colon)
+    "subject-full-stop": [RuleConfigSeverity.Error, "never", "."],
+
+    // Custom kit scope format
+    "kit-scope-format": [RuleConfigSeverity.Error, "always"],
+  },
+  ignores: [
+    (message) => message.includes("Merge pull request #"),
+    (message) => message.startsWith("Revert \""),
+  ],
+};

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,33 @@
+name: Lint Commit Messages
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  commitlint:
+    if: github.repository == 'bottlerocket-os/bottlerocket'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v4
+      - name: Install commitlint
+        run: npm install @commitlint/cli @commitlint/types
+      - name: Lint commits in PR
+        env:
+          WORKSPACE: ${{ github.workspace }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          npx commitlint \
+            -g "${WORKSPACE}/.commitlint.config.mjs" \
+            --from "${BASE_SHA}" \
+            --to "${HEAD_SHA}" \
+            --verbose


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

Add linting to commit messages for this repo. We've had some churn (and misses) the last few weeks on commit style, so let's enforce it via CI. The linting checks for `scope: message` style commits. This is slightly different than conventional commits, which are more the form `fix(scope): message` or `chore(scope): message`, but the linting is based on our own conventions and commit history.

**Testing done:**

Ran locally against last 50 commits. Only latest commit https://github.com/bottlerocket-os/bottlerocket/commit/0cef8091dbba23e670d9bad35bd98f0002ea420b failed because it is missing a colon.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
