### PR TITLE
twoliter: bump kernel-kit to v7.3.0

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "zfqd6UiE50c0yXGOC5dd9oCj5o0CFa41giNZnhNdzcw="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "7.2.1"
+version = "7.3.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v7.2.1"
-digest = "yyfbKes1Uhytp459V0rpQeED2VuJhuWh8i5VE4zSRlQ="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v7.3.0"
+digest = "1RO4bwUNthtmxFq5nTshmVNOpCXodZogx2lQA8eT9dM="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "7.2.1"
+version = "7.3.0"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
bumps kernel-kit version to v7.3.0

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
