### PR TITLE
twoliter: Bump kernel kit to v8.0.0

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "6dm8z91Cwe5BgAudM4XlkWPaF88bspeLBrjZ38VhKUs="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "7.4.0"
+version = "8.0.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v7.4.0"
-digest = "SQedSOyMa9kju9EwTwqWXsKfJ/LnnEKja9VkDEOzYro="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v8.0.0"
+digest = "xG+cTr3TQZLwe+gm4RRkxYgqWgXAMDJf9eIDLBEw+Yo="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "7.4.0"
+version = "8.0.0"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
**Description of changes:**
Update kernel kit to v8.0.0


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
