### PR TITLE
twoliter: Bump kernel-kit to 9.0.1

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "6dm8z91Cwe5BgAudM4XlkWPaF88bspeLBrjZ38VhKUs="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "8.0.0"
+version = "9.0.1"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v8.0.0"
-digest = "xG+cTr3TQZLwe+gm4RRkxYgqWgXAMDJf9eIDLBEw+Yo="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v9.0.1"
+digest = "6X+v8R2mCRkLmlD/N2wjz9mbNjp3EKG02a9bB1OcB20="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "8.0.0"
+version = "9.0.1"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Bump kernel-kit to 9.0.1 https://github.com/bottlerocket-os/bottlerocket-kernel-kit/releases/tag/v9.0.1

**Testing done:**

Built an aws-ecs-2 variant.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
