### PR TITLE
twoliter: Bump kernel-kit to 9.0.2

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -10,10 +10,10 @@ digest = "6dm8z91Cwe5BgAudM4XlkWPaF88bspeLBrjZ38VhKUs="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "9.0.1"
+version = "9.0.2"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v9.0.1"
-digest = "6X+v8R2mCRkLmlD/N2wjz9mbNjp3EKG02a9bB1OcB20="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v9.0.2"
+digest = "0XLkc/Oanfb5p02430XOsGHELUO72LPNaaYBON/1hk8="
 
 [[kit]]
 name = "bottlerocket-core-kit"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -12,7 +12,7 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "9.0.1"
+version = "9.0.2"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION

**Description of changes:**
Bump kernel-kit to 9.0.2 https://github.com/bottlerocket-os/bottlerocket-kernel-kit/releases/tag/v9.0.2



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
