### PR TITLE
twoliter: Bump core-kit to v16.1.0

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -17,7 +17,7 @@ digest = "0XLkc/Oanfb5p02430XOsGHELUO72LPNaaYBON/1hk8="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "15.1.0"
+version = "16.1.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v15.1.0"
-digest = "5xtWzYbApP6t1M918AHSduu4tOZWMrM3O0IzntCycEw="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v16.1.0"
+digest = "DqXpwe/tIyF4e3RAxD2tli4j38HtpBVmwEBdQ4R2AO4="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -17,5 +17,5 @@ vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "15.1.0"
+version = "16.1.0"
 vendor = "bottlerocket"


### PR DESCRIPTION

**Description of changes:**

Bump core-kit to v16.1.0 https://github.com/bottlerocket-os/bottlerocket-core-kit/releases/tag/v16.1.0


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
