### PR TITLE
twoliter: kit version bump

### DIFF
--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -7,15 +7,15 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.78.0"
+version = "0.79.0"
 vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "9.0.2"
+version = "9.1.0"
 vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "16.1.0"
+version = "16.2.0"
 vendor = "bottlerocket"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -7,7 +7,7 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.79.0"
+version = "0.78.0"
 vendor = "bottlerocket"
 
 [[kit]]

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -7,7 +7,7 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.78.0"
+version = "0.79.0"
 vendor = "bottlerocket"
 
 [[kit]]


### PR DESCRIPTION
**Description of changes:**

twoliter: bump core-kit to 16.2.0
twoliter: bump kernel-kit to 9.1.0
twoliter: bump SDK to 0.79.0

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
