### PR TITLE
Bump kits and SDK versions and fix clippy warnings

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -3,21 +3,21 @@ project-vendor = "Bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.78.0"
+version = "0.79.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.78.0"
-digest = "6dm8z91Cwe5BgAudM4XlkWPaF88bspeLBrjZ38VhKUs="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.79.0"
+digest = "B/dAUOA5VWlAWwbti5D/Q577BaupO87OqlcmQXiHvew="
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "9.0.2"
+version = "9.1.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v9.0.2"
-digest = "0XLkc/Oanfb5p02430XOsGHELUO72LPNaaYBON/1hk8="
+source = "public.ecr.aws/bottlerocket/bottlerocket-kernel-kit:v9.1.0"
+digest = "hNrjl3b0anJiUNnwiKw/gPZoCpq7pduMI8thTZloJdo="
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "16.1.0"
+version = "16.2.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v16.1.0"
-digest = "DqXpwe/tIyF4e3RAxD2tli4j38HtpBVmwEBdQ4R2AO4="
+source = "public.ecr.aws/bottlerocket/bottlerocket-core-kit:v16.2.0"
+digest = "O1opp76tjBi5ZM/LYoWIG8OQWOHlTsEKdCBUV4/vlVI="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -7,15 +7,15 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.78.0"
+version = "0.79.0"
 vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-kernel-kit"
-version = "9.0.2"
+version = "9.1.0"
 vendor = "bottlerocket"
 
 [[kit]]
 name = "bottlerocket-core-kit"
-version = "16.1.0"
+version = "16.2.0"
 vendor = "bottlerocket"

--- a/sources/api/datastore/src/deserialization/pairs.rs
+++ b/sources/api/datastore/src/deserialization/pairs.rs
@@ -285,18 +285,18 @@ where
                     return None;
                 }
             };
-            trace!("Visiting key '{}', struct name '{}'", key, &struct_name);
+            trace!("Visiting key '{}', struct name '{}'", key, struct_name);
 
             // At the top level (None path) we start with struct_name as Key, otherwise append
             // struct_name.
-            trace!("Old path: {:?}", &self.path);
+            trace!("Old path: {:?}", self.path);
             let path = match self.path {
                 None => match Key::from_segments(KeyType::Data, &[&struct_name]) {
                     Ok(key) => key,
                     Err(e) => {
                         error!(
                             "Tried to construct invalid key from struct name '{}', skipping: {}",
-                            &struct_name, e
+                            struct_name, e
                         );
                         return None;
                     }
@@ -306,18 +306,18 @@ where
                     Err(e) => {
                         error!(
                             "Appending '{}' to existing key '{}' resulted in invalid key, skipping: {}",
-                            old_path, &struct_name, e
+                            old_path, struct_name, e
                         );
                         return None;
                     }
                 }
             };
-            trace!("New path: {}", &path);
+            trace!("New path: {}", path);
 
             if !segments.is_empty() {
                 if structs_done.contains(&struct_name) {
                     // We've handled this structure with a recursive call, so we're done.
-                    trace!("Already handled struct '{}', skipping", &struct_name);
+                    trace!("Already handled struct '{}', skipping", struct_name);
                     None
                 } else {
                     // Otherwise, mark it, and recurse.
@@ -332,13 +332,13 @@ where
                         // Remove the prefix - should always work, but log and skip the key otherwise
                         .filter_map(|new_key| new_key
                                     .strip_prefix(&struct_name)
-                                    .map_err(|e| error!("Key starting with segment '{}' couldn't remove it as prefix: {}", &struct_name, e)).ok())
+                                    .map_err(|e| error!("Key starting with segment '{}' couldn't remove it as prefix: {}", struct_name, e)).ok())
                         .collect();
 
                     // And here's what MapDeserializer expects, the key and deserializer for it
                     trace!(
                         "Recursing for struct '{}' with keys: {:?}",
-                        &struct_name,
+                        struct_name,
                         keys
                     );
                     Some((

--- a/sources/api/datastore/src/filesystem.rs
+++ b/sources/api/datastore/src/filesystem.rs
@@ -563,7 +563,7 @@ impl DataStore for FilesystemDataStore {
 
         // Pull out just the keys so we can log them and return them
         let pending_keys = pending_data.into_keys().collect();
-        debug!("Found pending keys: {:?}", &pending_keys);
+        debug!("Found pending keys: {:?}", pending_keys);
 
         // Delete pending from the filesystem, same as a commit
         let path = self.base_path(&pending);

--- a/sources/api/datastore/src/lib.rs
+++ b/sources/api/datastore/src/lib.rs
@@ -258,7 +258,7 @@ pub trait DataStore {
                 trace!(
                     "Pulling metadata '{}' from datastore for key: {}",
                     meta_key,
-                    &data_key
+                    data_key
                 );
                 let value = self
                     .get_metadata(&meta_key, &data_key, committed)?

--- a/sources/api/datastore/src/serialization/pairs.rs
+++ b/sources/api/datastore/src/serialization/pairs.rs
@@ -347,7 +347,7 @@ impl ser::SerializeMap for Serializer<'_> {
         // meaning it's in quoted form.
         let key = Key::new(KeyType::Data, &key_str).map_err(|e| {
             error::InvalidKeySnafu {
-                msg: format!("serialized map key '{}' not valid as Key: {}", &key_str, e),
+                msg: format!("serialized map key '{}' not valid as Key: {}", key_str, e),
             }
             .into_error(NoSource)
         })?;
@@ -406,7 +406,7 @@ impl ser::SerializeStruct for Serializer<'_> {
             "Recursively serializing struct with new root '{}' from prefix '{:?}' and key '{}'",
             new_root,
             self.prefix,
-            &key
+            key
         );
         value.serialize(Serializer::new(self.output, Some(new_root)))
     }


### PR DESCRIPTION
**Description of changes:**
- Bump SDK to 0.79.0
- bump kits to latest
- fix clippy warnings


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
