### PR TITLE
variants: remove metric-dog defaults from aws-dev variant

### DIFF
--- a/sources/settings-defaults/aws-dev/defaults.d/30-metrics.toml
+++ b/sources/settings-defaults/aws-dev/defaults.d/30-metrics.toml
@@ -1,1 +1,0 @@
-../../../shared-defaults/metrics.toml

--- a/sources/settings-defaults/aws-dev/defaults.d/31-send-metrics-aws.toml
+++ b/sources/settings-defaults/aws-dev/defaults.d/31-send-metrics-aws.toml
@@ -1,1 +1,0 @@
-../../../shared-defaults/send-metrics-aws.toml


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
- Remove `settings.metrics` defaults from aws-dev


**Testing done:**
- Built `aws-dev` variant and booted AMI. Ensure no services fail.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
