### PR TITLE
variants: add k8s-1.37 variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-k8s-1_37"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "aws-k8s-1_37-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "aws-k8s-1_37-nvidia"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "aws-k8s-1_37-nvidia-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
 name = "aws-mantle-1"
 version = "0.1.0"
 dependencies = [
@@ -484,6 +520,24 @@ dependencies = [
 
 [[package]]
 name = "vmware-k8s-1_36-fips"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "vmware-k8s-1_37"
+version = "0.1.0"
+dependencies = [
+ "settings-defaults",
+ "settings-migrations",
+ "settings-plugins",
+]
+
+[[package]]
+name = "vmware-k8s-1_37-fips"
 version = "0.1.0"
 dependencies = [
  "settings-defaults",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ members = [
     "variants/aws-k8s-1.35-fips",
     "variants/aws-k8s-1.36",
     "variants/aws-k8s-1.36-fips",
+    "variants/aws-k8s-1.37",
+    "variants/aws-k8s-1.37-fips",
     "variants/aws-k8s-1.31-nvidia",
     "variants/aws-k8s-1.31-nvidia-fips",
     "variants/aws-k8s-1.32-nvidia",
@@ -43,6 +45,8 @@ members = [
     "variants/aws-k8s-1.35-nvidia-fips",
     "variants/aws-k8s-1.36-nvidia",
     "variants/aws-k8s-1.36-nvidia-fips",
+    "variants/aws-k8s-1.37-nvidia",
+    "variants/aws-k8s-1.37-nvidia-fips",
     "variants/metal-dev",
     "variants/vmware-dev",
     "variants/vmware-k8s-1.31",
@@ -57,6 +61,8 @@ members = [
     "variants/vmware-k8s-1.35-fips",
     "variants/vmware-k8s-1.36",
     "variants/vmware-k8s-1.36-fips",
+    "variants/vmware-k8s-1.37",
+    "variants/vmware-k8s-1.37-fips",
 ]
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -67,12 +67,14 @@ The following variants support EKS, as described above:
 * `aws-k8s-1.34`
 * `aws-k8s-1.35`
 * `aws-k8s-1.36`
+* `aws-k8s-1.37`
 * `aws-k8s-1.31-nvidia`
 * `aws-k8s-1.32-nvidia`
 * `aws-k8s-1.33-nvidia`
 * `aws-k8s-1.34-nvidia`
 * `aws-k8s-1.35-nvidia`
 * `aws-k8s-1.36-nvidia`
+* `aws-k8s-1.37-nvidia`
 
 The following variants support ECS:
 
@@ -90,6 +92,7 @@ We also have variants that are designed to be Kubernetes worker nodes in VMware:
 * `vmware-k8s-1.34`
 * `vmware-k8s-1.35`
 * `vmware-k8s-1.36`
+* `vmware-k8s-1.37`
 
 The following variants are no longer supported:
 

--- a/packages/settings-defaults/settings-defaults.spec
+++ b/packages/settings-defaults/settings-defaults.spec
@@ -303,6 +303,34 @@ Conflicts: %{_cross_os}settings-defaults(any)
 %description aws-k8s-1.36-nvidia
 %{summary}.
 
+%package aws-k8s-1.37
+Summary: Settings defaults for the aws-k8s 1.37 variants
+Requires: (%{shrink:
+           %{_cross_os}variant(aws-k8s-1.37)      or
+           %{_cross_os}variant(aws-k8s-1.37-fips)
+           %{nil}})
+Provides: %{_cross_os}settings-defaults(any)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.37)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.37-fips)
+Conflicts: %{_cross_os}settings-defaults(any)
+
+%description aws-k8s-1.37
+%{summary}.
+
+%package aws-k8s-1.37-nvidia
+Summary: Settings defaults for the aws-k8s 1.37 nvidia variants
+Requires: (%{shrink:
+           %{_cross_os}variant(aws-k8s-1.37-nvidia)      or
+           %{_cross_os}variant(aws-k8s-1.37-nvidia-fips)
+           %{nil}})
+Provides: %{_cross_os}settings-defaults(any)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.37-nvidia)
+Provides: %{_cross_os}settings-defaults(aws-k8s-1.37-nvidia-fips)
+Conflicts: %{_cross_os}settings-defaults(any)
+
+%description aws-k8s-1.37-nvidia
+%{summary}.
+
 %package metal-dev
 Summary: Settings defaults for the metal-dev variant
 Requires: %{_cross_os}variant(metal-dev)
@@ -397,6 +425,20 @@ Conflicts: %{_cross_os}settings-defaults(any)
 %description vmware-k8s-1.36
 %{summary}.
 
+%package vmware-k8s-1.37
+Summary: Settings defaults for the vmware-k8s 1.37 variants
+Requires: (%{shrink:
+           %{_cross_os}variant(vmware-k8s-1.37)      or
+           %{_cross_os}variant(vmware-k8s-1.37-fips)
+           %{nil}})
+Provides: %{_cross_os}settings-defaults(any)
+Provides: %{_cross_os}settings-defaults(vmware-k8s-1.37)
+Provides: %{_cross_os}settings-defaults(vmware-k8s-1.37-fips)
+Conflicts: %{_cross_os}settings-defaults(any)
+
+%description vmware-k8s-1.37
+%{summary}.
+
 %prep
 %setup -T -c
 %cargo_prep
@@ -425,6 +467,8 @@ for defaults in \
   aws-k8s-1.35-nvidia \
   aws-k8s-1.36 \
   aws-k8s-1.36-nvidia \
+  aws-k8s-1.37 \
+  aws-k8s-1.37-nvidia \
   metal-dev \
   vmware-dev \
   vmware-k8s-1.32 \
@@ -432,6 +476,7 @@ for defaults in \
   vmware-k8s-1.34 \
   vmware-k8s-1.35 \
   vmware-k8s-1.36 \
+  vmware-k8s-1.37 \
   ;
 do
   projects+=( "-p" "settings-defaults-$(echo "${defaults}" | sed -e 's,\.,_,g')" )
@@ -473,6 +518,8 @@ for defaults in \
   aws-k8s-1.35-nvidia \
   aws-k8s-1.36 \
   aws-k8s-1.36-nvidia \
+  aws-k8s-1.37 \
+  aws-k8s-1.37-nvidia \
   metal-dev \
   vmware-dev \
   vmware-k8s-1.32 \
@@ -480,6 +527,7 @@ for defaults in \
   vmware-k8s-1.34 \
   vmware-k8s-1.35 \
   vmware-k8s-1.36 \
+  vmware-k8s-1.37 \
   ;
 do
   crate="$(echo "${defaults}" | sed -e 's,\.,_,g')"
@@ -578,6 +626,14 @@ done
 %{_cross_defaultsdir}/aws-k8s-1.36-nvidia.toml
 %{_cross_tmpfilesdir}/storewolf-defaults-aws-k8s-1.36-nvidia.conf
 
+%files aws-k8s-1.37
+%{_cross_defaultsdir}/aws-k8s-1.37.toml
+%{_cross_tmpfilesdir}/storewolf-defaults-aws-k8s-1.37.conf
+
+%files aws-k8s-1.37-nvidia
+%{_cross_defaultsdir}/aws-k8s-1.37-nvidia.toml
+%{_cross_tmpfilesdir}/storewolf-defaults-aws-k8s-1.37-nvidia.conf
+
 %files metal-dev
 %{_cross_defaultsdir}/metal-dev.toml
 %{_cross_tmpfilesdir}/storewolf-defaults-metal-dev.conf
@@ -605,3 +661,7 @@ done
 %files vmware-k8s-1.36
 %{_cross_defaultsdir}/vmware-k8s-1.36.toml
 %{_cross_tmpfilesdir}/storewolf-defaults-vmware-k8s-1.36.conf
+
+%files vmware-k8s-1.37
+%{_cross_defaultsdir}/vmware-k8s-1.37.toml
+%{_cross_tmpfilesdir}/storewolf-defaults-vmware-k8s-1.37.conf

--- a/packages/settings-plugins/settings-plugins.spec
+++ b/packages/settings-plugins/settings-plugins.spec
@@ -114,6 +114,8 @@ Provides: %{_cross_os}settings-plugin(aws-k8s-1.35)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.35-fips)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.36)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.36-fips)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.37)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.37-fips)
 Conflicts: %{_cross_os}settings-plugin(any)
 Conflicts: %{_cross_os}variant-flavor(nvidia)
 
@@ -137,6 +139,8 @@ Provides: %{_cross_os}settings-plugin(aws-k8s-1.35-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.35-nvidia-fips)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.36-nvidia)
 Provides: %{_cross_os}settings-plugin(aws-k8s-1.36-nvidia-fips)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.37-nvidia)
+Provides: %{_cross_os}settings-plugin(aws-k8s-1.37-nvidia-fips)
 Conflicts: %{_cross_os}settings-plugin(any)
 
 %description aws-k8s-nvidia
@@ -178,6 +182,8 @@ Provides: %{_cross_os}settings-plugin(vmware-k8s-1.35)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.35-fips)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.36)
 Provides: %{_cross_os}settings-plugin(vmware-k8s-1.36-fips)
+Provides: %{_cross_os}settings-plugin(vmware-k8s-1.37)
+Provides: %{_cross_os}settings-plugin(vmware-k8s-1.37-fips)
 Conflicts: %{_cross_os}settings-plugin(any)
 
 %description vmware-k8s

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2044,6 +2044,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-defaults-aws-k8s-1_37"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-defaults-helper",
+]
+
+[[package]]
+name = "settings-defaults-aws-k8s-1_37-nvidia"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-defaults-helper",
+]
+
+[[package]]
 name = "settings-defaults-aws-mantle-1"
 version = "0.1.0"
 dependencies = [
@@ -2108,6 +2122,13 @@ dependencies = [
 
 [[package]]
 name = "settings-defaults-vmware-k8s-1_36"
+version = "0.1.0"
+dependencies = [
+ "bottlerocket-defaults-helper",
+]
+
+[[package]]
+name = "settings-defaults-vmware-k8s-1_37"
 version = "0.1.0"
 dependencies = [
  "bottlerocket-defaults-helper",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -32,6 +32,8 @@ members = [
     "settings-defaults/aws-k8s-1.35-nvidia",
     "settings-defaults/aws-k8s-1.36",
     "settings-defaults/aws-k8s-1.36-nvidia",
+    "settings-defaults/aws-k8s-1.37",
+    "settings-defaults/aws-k8s-1.37-nvidia",
     "settings-defaults/aws-mantle-1",
     "settings-defaults/aws-mantle-1-nvidia",
     "settings-defaults/metal-dev",
@@ -42,6 +44,7 @@ members = [
     "settings-defaults/vmware-k8s-1.34",
     "settings-defaults/vmware-k8s-1.35",
     "settings-defaults/vmware-k8s-1.36",
+    "settings-defaults/vmware-k8s-1.37",
 
     # (all previous migrations archived; add new ones after this line)
     "settings-migrations/v1.34.0/kubelet-device-plugins-mig-settings",

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "settings-defaults-aws-k8s-1_37-nvidia"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+build = "../build-defaults.rs"
+
+[lib]
+path = "../defaults-toml.rs"
+
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/10-defaults.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/15-aws-tuf.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/20-aws-host-containers.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/20-aws-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-host-containers.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/25-cf-signal.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/26-aws-autoscaling.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/30-metrics.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/31-send-metrics-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/50-kubernetes-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/50-kubernetes-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/51-kubernetes-containerd-nvidia.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/51-kubernetes-containerd-nvidia.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-containerd-nvidia.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/52-kubernetes-services.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/52-kubernetes-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-services.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-external-cloud-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/55-kubernetes-aws-credential-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/55-kubernetes-aws-credential-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-credential-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/56-kubernetes-seccomp-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/56-kubernetes-seccomp-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-seccomp-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/57-kubernetes-device-ownership-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/57-kubernetes-device-ownership-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-device-ownership-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/58-kubernetes-graceful-shutdown.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/58-kubernetes-graceful-shutdown.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-graceful-shutdown.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/59-kubernetes-kubelet-env-nvidia.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/59-kubernetes-kubelet-env-nvidia.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-kubelet-env-nvidia.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/60-lockdown-none.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/60-lockdown-none.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-none.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/70-oci-hooks.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/75-oci-defaults-containerd-cri.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/75-oci-defaults-containerd-cri.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/76-oci-defaults-capabilities.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/76-oci-defaults-capabilities.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-capabilities.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri-resource-limits.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/80-nvidia-k8s-container-toolkit.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-container-toolkit.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/81-nvidia-k8s-device-plugin.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/82-nvidia-k8s-device-plugin-cdi.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/82-nvidia-k8s-device-plugin-cdi.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/nvidia-k8s-device-plugin-cdi.toml

--- a/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/90-boot.toml
+++ b/sources/settings-defaults/aws-k8s-1.37-nvidia/defaults.d/90-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/sources/settings-defaults/aws-k8s-1.37/Cargo.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "settings-defaults-aws-k8s-1_37"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+build = "../build-defaults.rs"
+
+[lib]
+path = "../defaults-toml.rs"
+
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/10-defaults.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/15-aws-tuf.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/15-aws-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-tuf.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/20-aws-host-containers.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/20-aws-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-host-containers.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/21-aws-bootstrap-container.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/21-aws-bootstrap-container.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-bootstrap-container.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/25-cf-signal.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/25-cf-signal.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/cf-signal.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/26-aws-autoscaling.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/26-aws-autoscaling.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-autoscaling.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/30-metrics.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/31-send-metrics-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/31-send-metrics-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/50-kubernetes-aws.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/50-kubernetes-aws.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/51-kubernetes-containerd.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/51-kubernetes-containerd.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-containerd.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/52-kubernetes-services.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/52-kubernetes-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-services.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/54-kubernetes-aws-external-cloud-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-external-cloud-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/55-kubernetes-aws-credential-provider.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/55-kubernetes-aws-credential-provider.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-credential-provider.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/56-kubernetes-seccomp-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/56-kubernetes-seccomp-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-seccomp-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/57-kubernetes-device-ownership-default-true.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/57-kubernetes-device-ownership-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-device-ownership-default-true.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/58-kubernetes-graceful-shutdown.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/58-kubernetes-graceful-shutdown.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-aws-graceful-shutdown.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/60-lockdown-integrity.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/60-lockdown-integrity.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-integrity.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/70-oci-hooks.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/70-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/75-oci-defaults-containerd-cri.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/75-oci-defaults-containerd-cri.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/76-oci-defaults-capabilities.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/76-oci-defaults-capabilities.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-capabilities.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri-resource-limits.toml

--- a/sources/settings-defaults/aws-k8s-1.37/defaults.d/90-boot.toml
+++ b/sources/settings-defaults/aws-k8s-1.37/defaults.d/90-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/Cargo.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "settings-defaults-vmware-k8s-1_37"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+build = "../build-defaults.rs"
+
+[lib]
+path = "../defaults-toml.rs"
+
+[build-dependencies]
+bottlerocket-defaults-helper.workspace = true

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/10-defaults.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/10-defaults.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/defaults.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/11-updates.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/11-updates.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/updates.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/15-public-tuf.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/15-public-tuf.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-tuf.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/20-public-host-containers.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/20-public-host-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-host-containers.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/21-public-bootstrap-containers.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/21-public-bootstrap-containers.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-bootstrap-containers.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/30-metrics.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/30-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/metrics.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/31-send-metrics.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/31-send-metrics.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/send-metrics-global.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/40-aws-creds.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/40-aws-creds.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/aws-creds.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/50-kubernetes-vmware.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/50-kubernetes-vmware.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-vmware.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/51-kubernetes-containerd.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/51-kubernetes-containerd.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-containerd.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/52-kubernetes-services.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/52-kubernetes-services.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-services.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/53-containerd-cri-pki.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/53-containerd-cri-pki.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/containerd-cri-pki.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/54-kubernetes-seccomp-default-true.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/54-kubernetes-seccomp-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-seccomp-default-true.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/55-kubernetes-device-ownership-default-true.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/55-kubernetes-device-ownership-default-true.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/kubernetes-device-ownership-default-true.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/58-image-verification.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/58-image-verification.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/image-verification.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/60-lockdown-integrity.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/60-lockdown-integrity.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/lockdown-integrity.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/70-public-ntp.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/70-public-ntp.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/public-ntp.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/75-oci-defaults-containerd-cri.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/75-oci-defaults-containerd-cri.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/76-oci-defaults-capabilities.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/76-oci-defaults-capabilities.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-capabilities.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/77-oci-defaults-containerd-cri-resource-limits.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-defaults-containerd-cri-resource-limits.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/80-oci-hooks.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/80-oci-hooks.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/oci-hooks.toml

--- a/sources/settings-defaults/vmware-k8s-1.37/defaults.d/90-boot.toml
+++ b/sources/settings-defaults/vmware-k8s-1.37/defaults.d/90-boot.toml
@@ -1,0 +1,1 @@
+../../../shared-defaults/boot.toml

--- a/variants/aws-k8s-1.37-fips/Cargo.toml
+++ b/variants/aws-k8s-1.37-fips/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+# This is the aws-k8s-1.37-fips variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_37-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+fips = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release-swap",
+    "kernel-6.18",
+    "containerd-2.3",
+    "systemd-257",
+    "nftables",
+    "whippet",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.37",
+    "aws-iam-authenticator",
+    "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.37-fips/amispec.toml
+++ b/variants/aws-k8s-1.37-fips/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/aws-k8s-1.37-nvidia-fips/Cargo.toml
+++ b/variants/aws-k8s-1.37-nvidia-fips/Cargo.toml
@@ -1,0 +1,62 @@
+[package]
+# This is the aws-k8s-1.37-nvidia-fips variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_37-nvidia-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+fips = true
+
+[package.metadata.build-variant]
+included-packages = [
+    # core
+    "release-swap",
+    "kernel-6.18",
+    "containerd-2.3",
+    "systemd-257",
+    "nftables",
+    "whippet",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.37",
+    "aws-iam-authenticator",
+    "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
+    # nvidia
+    "nvidia-container-toolkit-k8s",
+    "nvidia-k8s-device-plugin",
+    "kmod-6.18-nvidia-r580-tesla",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.37-nvidia-fips/amispec.toml
+++ b/variants/aws-k8s-1.37-nvidia-fips/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/aws-k8s-1.37-nvidia/Cargo.toml
+++ b/variants/aws-k8s-1.37-nvidia/Cargo.toml
@@ -1,0 +1,61 @@
+[package]
+# This is the aws-k8s-1.37-nvidia variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_37-nvidia"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+included-packages = [
+    # core
+    "release-swap",
+    "kernel-6.18",
+    "containerd-2.3",
+    "systemd-257",
+    "nftables",
+    "whippet",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.37",
+    "aws-iam-authenticator",
+    "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
+    # nvidia
+    "nvidia-container-toolkit-k8s",
+    "nvidia-k8s-device-plugin",
+    "kmod-6.18-nvidia-r580-tesla",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.37-nvidia/amispec.toml
+++ b/variants/aws-k8s-1.37-nvidia/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/aws-k8s-1.37/Cargo.toml
+++ b/variants/aws-k8s-1.37/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+# This is the aws-k8s-1.37 variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_37"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+included-packages = [
+# core
+    "release-swap",
+    "kernel-6.18",
+    "containerd-2.3",
+    "systemd-257",
+    "nftables",
+    "whippet",
+# k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.37",
+    "aws-iam-authenticator",
+    "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/aws-k8s-1.37/amispec.toml
+++ b/variants/aws-k8s-1.37/amispec.toml
@@ -1,0 +1,1 @@
+../shared/amispec-split.toml

--- a/variants/vmware-k8s-1.37-fips/Cargo.toml
+++ b/variants/vmware-k8s-1.37-fips/Cargo.toml
@@ -1,0 +1,62 @@
+[package]
+# This is the vmware-k8s-1.37-fips variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_37-fips"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+fips = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    # core
+    "release-swap",
+    "kernel-6.18",
+    "containerd-2.3",
+    "systemd-257",
+    "nftables",
+    "whippet",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.37",
+    "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
+    # vmware
+    "open-vm-tools",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.37-fips/template.ovf
+++ b/variants/vmware-k8s-1.37-fips/template.ovf
@@ -1,0 +1,1 @@
+../shared/template-unified-secboot.ovf

--- a/variants/vmware-k8s-1.37/Cargo.toml
+++ b/variants/vmware-k8s-1.37/Cargo.toml
@@ -1,0 +1,61 @@
+[package]
+# This is the vmware-k8s-1.37 variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_37"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+uefi-secure-boot = true
+xfs-data-partition = true
+erofs-root-partition = true
+systemd-networkd = true
+external-kmod-development = false
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    # core
+    "release-swap",
+    "kernel-6.18",
+    "containerd-2.3",
+    "systemd-257",
+    "nftables",
+    "whippet",
+    # k8s
+    "cni",
+    "cni-plugins",
+    "kubelet-1.37",
+    "soci-snapshotter",
+    "aws-signer-notation-plugin",
+    "digestion-image-verifier",
+    "notation-image-verifier",
+    "thar-be-image-verifiers",
+    # vmware
+    "open-vm-tools",
+]
+
+[lib]
+path = "../variants.rs"
+
+[build-dependencies]
+settings-defaults = { path = "../../packages/settings-defaults" }
+settings-plugins = { path = "../../packages/settings-plugins" }
+settings-migrations = { path = "../../packages/settings-migrations" }

--- a/variants/vmware-k8s-1.37/template.ovf
+++ b/variants/vmware-k8s-1.37/template.ovf
@@ -1,0 +1,1 @@
+../shared/template-unified-secboot.ovf


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related #4915

**Description of changes:**
  - Add new k8s-1.37 variants.
  - All variants use `kernel-6.18` and `containerd-2.3`.

Related core-kit changes: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/1029

**Testing done:**
  - Kubernetes conformance and targeted feature testing are documented in [bottlerocket-core-kit#1029](https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/1029).
  - FIPS testing passed
  ```
bash-5.2# apiclient report fips
Benchmark name:  FIPS Security Policy
Version:         v1.0.0
Reference:       https://csrc.nist.gov/
Benchmark level: 1
Start time:      2026-09-16T22:20:20.368219131Z

[PASS] 1.0       FIPS mode is enabled. (Automatic)
[PASS] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
[PASS] 1.2       FIPS self-tests passed. (Automatic)

Passed:          3
Failed:          0
Skipped:         0
Total checks:    3

bash-5.2# cat /proc/cmdline
SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1 SYSTEMD_DEFAULT_MOUNT_RATE_LIMIT_BURST=25 fips=1 module_blacklist=i8042 BOOT_IMAGE=/vmlinuz console=tty0 console=ttyS0,115200n8 net.ifnames=0 netdog.default-interface=eth0:dhcp4,dhcp6? quiet bootconfig root=/dev/dm-0 rootwait ro raid=noautodetect random.trust_cpu=on selinux=1 enforcing=1 "dm-mod.create=root,,,ro,0 689808 verity 1 PARTUUID=bd32b768-0fec-4627-a6ce-73aba1d05f6e/PARTNROFF=1 PARTUUID=bd32b768-0fec-4627-a6ce-73aba1d05f6e/PARTNROFF=2 4096 4096 86226 1 sha256 1985fa08a649ef93f9dba0af1f10b4a146e22206f1006d1421e67eac0fa600cf 269419a2ea811d3d6e074c2f8fdc8013957326fcab28802d021c5bb475bf3228 2 restart_on_corruption ignore_zero_blocks" -- systemd.unit=fipscheck.target systemd.log_target=journal-or-kmsg systemd.log_color=0 systemd.show_status=true
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
